### PR TITLE
In POC dropdown, only show POCs where EmployeeType is not blank

### DIFF
--- a/api/queries/GET/get_pocs.sql
+++ b/api/queries/GET/get_pocs.sql
@@ -6,4 +6,6 @@ SELECT
   poc.OrgCode                                 AS Organization
 
 FROM obj_ldap_poc                             AS poc
-WHERE poc.Enabled = 'TRUE'
+WHERE poc.Enabled = 'TRUE' 
+  AND poc.EmployeeType IS NOT null
+  AND poc.EmployeeType <> ''


### PR DESCRIPTION
this is related to issue #215 