### PR TITLE
Update it-standards-modal.component.html

### DIFF
--- a/src/app/components/modals/it-standards-modal/it-standards-modal.component.html
+++ b/src/app/components/modals/it-standards-modal/it-standards-modal.component.html
@@ -80,7 +80,7 @@
                 </div>
               </div>
               <div class="overview-item">
-                <div class="overview-item-title" [title]="getTooltip('Previously Known As')" role="tooltip">
+                <div class="overview-item-title" [title]="getTooltip('Also Known As')" role="tooltip">
                   <i class="fa fa-info-circle"></i>
                   <span class="heading">Also Known As</span>
                 </div>


### PR DESCRIPTION
Changing the IT standards modal tooltip on the "Also Known As" field to reference the new name in the database (previously it was Previously Known As)