### PR TITLE
Added tooltips for OS and app bundles to the it standard report. Move…

### DIFF
--- a/src/app/components/modals/it-standards-modal/it-standards-modal.component.html
+++ b/src/app/components/modals/it-standards-modal/it-standards-modal.component.html
@@ -117,15 +117,6 @@
                 </div>
               </div>
               <div class="overview-item">
-                <div class="overview-item-title" [title]="getTooltip('App Bundle Ids')" role="tooltip">
-                  <i class="fa fa-info-circle"></i>
-                  <span class="heading">App Bundle Id(s)</span>
-                </div>
-                <div class="overview-item-content">
-                  <ul [innerHTML]="renderListFromCsvString(itStandard.AppBundleIds)"></ul>
-                </div>
-              </div>
-              <div class="overview-item">
                 <div class="overview-item-title" [title]="getTooltip('Deployment Type')" role="tooltip">
                   <i class="fa fa-shipping-fast"></i>
                   <span class="heading">Deployment Type</span>
@@ -262,6 +253,10 @@
                       {{ itStandard.ReferenceDocument }}</a>
                     <div [hidden]="itStandard.ReferenceDocument">None</div>
                   </td>
+                </tr>
+                <tr *ngIf="isFieldPopulated(itStandard.AppBundleIds)">
+                  <td><i class="fas fa-info-circle"></i><span [title]="getTooltip('App Bundle Ids')" role="tooltip">App Bundle IDs</span></td>
+                  <td [innerHtml]="renderListFromCsvString(itStandard.AppBundleIds)"></td>
                 </tr>
               </tbody>
             </table>

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -253,6 +253,7 @@ export class ItStandardsComponent implements OnInit {
       sortable: false,
       visible: false,
       formatter: this.sharedService.csvFormatter,
+      titleTooltip: this.getTooltip('Operating Systems')
     },
     {
       field: 'AppBundleIds',
@@ -260,6 +261,7 @@ export class ItStandardsComponent implements OnInit {
       sortable: false,
       visible: false,
       formatter: this.sharedService.csvFormatter,
+      titleTooltip: this.getTooltip('App Bundle Ids')
     }];
 
       $('#itStandardsTable').bootstrapTable(


### PR DESCRIPTION
…d the App bundle field in the it standard modal to the table at the bottom

@hatfieldjm4 This is for both #563  and #564 