### PR TITLE
fix: enable horizontal scrolling and dynamic SVG expansion

### DIFF
--- a/src/app/views/enterprise/organizations-chart/organizations-chart.component.scss
+++ b/src/app/views/enterprise/organizations-chart/organizations-chart.component.scss
@@ -20,12 +20,19 @@
 }
 
 /* Keeping this here in case the detail pane gets larger and needs to move */
-/* #orgChart {
-  z-index: 1;
-  -moz-transition: all 0.3s linear;
-  -webkit-transition: all 0.3s linear;
-  transition: all 0.3s linear;
-} */
+#orgChart {
+  width: 100%;
+  min-height: 600px;
+
+  display: block;        /* FIX: remove flex */
+  overflow-x: auto;      /* enable horizontal scroll */
+  overflow-y: hidden;    /* optional: cleaner */
+}
+
+/* IMPORTANT: allow svg to grow wider than container */
+#orgChart svg {
+  display: block;
+}
 
 .org-container {
   display: flex;


### PR DESCRIPTION
BUG: https://github.com/GSA/GEAR3/issues/966

FIx: Updated the #orgChart styling to fix a layout issue that was preventing proper horizontal scrolling and expansion of the D3 chart. 
Issue: the container was using display: flex, which caused the browser to try to constrain the SVG within the available space instead of allowing it to overflow. By switching it to display: block, we let the SVG expand naturally based on its computed width. 
Add Fix: enabled overflow-x: auto so that when the SVG grows wider than the viewport, the container provides a horizontal scrollbar
Scoped the SVG styling under #orgChart and set it to display: block to ensure it behaves like a full-width element and doesn’t inherit inline rendering quirks. 
Summary: these changes ensure that the chart can expand dynamically and remain fully navigable even for deeper hierarchies.

<img width="1290" height="673" alt="image" src="https://github.com/user-attachments/assets/35d8b20b-8c97-4165-bd15-0f5ab0445c82" />

