### PR TITLE
fix: added manual reset button next to the Add/Remove Columns dropdow…

### DIFF
--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -65,6 +65,13 @@
                         <i class="fa fa-th-list"></i>
                       </ng-template>
                     </p-multiSelect>
+                    <p-button
+                      icon="fa fa-undo"
+                      pTooltip="Reset columns to default"
+                      tooltipPosition="left"
+                      severity="secondary"
+                      (click)="resetVisibleColumns()"
+                      ariaLabel="Reset Columns" />
                   }
                   @if (showExportButton) {
                     <p-button icon="fa fa-download" pTooltip="Export table data" tooltipPosition="left" severity="primary" (click)="exportSanitizedData()" ariaLabel="Export Data" />

--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -65,13 +65,7 @@
                         <i class="fa fa-th-list"></i>
                       </ng-template>
                     </p-multiSelect>
-                    <p-button
-                      icon="fa fa-undo"
-                      pTooltip="Reset columns to default"
-                      tooltipPosition="left"
-                      severity="secondary"
-                      (click)="resetVisibleColumns()"
-                      ariaLabel="Reset Columns" />
+                    <p-button icon="fa fa-undo" pTooltip="Reset columns to default" tooltipPosition="left" severity="primary" (click)="resetVisibleColumns()" ariaLabel="Reset Columns" />
                   }
                   @if (showExportButton) {
                     <p-button icon="fa fa-download" pTooltip="Export table data" tooltipPosition="left" severity="primary" (click)="exportSanitizedData()" ariaLabel="Export Data" />

--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, HostListener, Input, OnChanges, OnDestroy, OnI
 import { Table, TableLazyLoadEvent, TableRowSelectEvent } from 'primeng/table';
 import { Column, ExportColumn, TwoDimArray, FilterButton, ColumnFilter } from '../../common/table-classes';
 import { SharedService } from '@services/shared/shared.service';
+import { CookieService } from '@services/shared/cookie.service';
 import { TableService } from '@services/tables/table.service';
 import { ApiService } from '@services/apis/api.service';
 import { FilterMatchMode, SelectItem } from 'primeng/api';
@@ -128,6 +129,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
 
   constructor(
     private sharedService: SharedService,
+    private cookieService: CookieService,
     private tableService: TableService,
     private apiService: ApiService,
     private router: Router,
@@ -235,7 +237,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
       return null;
     }
 
-    return this.sharedService.getJsonCookie<string[]>(this.visibleColumnStorageKey);
+    return this.cookieService.getJsonCookie<string[]>(this.visibleColumnStorageKey);
   }
 
   private applySavedColumnVisibility(savedFields: string[]): void {
@@ -253,7 +255,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
     });
 
     if (this.visibleColumnStorageKey) {
-      this.sharedService.deleteCookie(this.visibleColumnStorageKey);
+      this.cookieService.deleteCookie(this.visibleColumnStorageKey);
     }
 
     this.initializeColumnVisibility();
@@ -284,7 +286,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
 
     if(this.visibleColumnStorageKey) {
       const selectedFields = this.visibleColumns.map(col => col.field).filter(field => !!field);
-      this.sharedService.setJsonCookie(this.visibleColumnStorageKey, selectedFields);
+      this.cookieService.setJsonCookie(this.visibleColumnStorageKey, selectedFields);
     }
   }
 

--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -125,7 +125,6 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
   private urlSearchTerm: string = '';
   private isHandlingDataUpdate: boolean = false;
   private defaultColumnVisibility: Map<string, boolean> = new Map();
-  private readonly visibleColumnsExpirationMs: number = 12 * 60 * 60 * 1000;
 
   constructor(
     private sharedService: SharedService,
@@ -200,12 +199,19 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
       this.captureDefaultColumnVisibility();
     }
 
-    const savedColumnFields = this.getSavedVisibleColumnFields();
-    if (savedColumnFields) {
-      this.applySavedColumnVisibility(savedColumnFields);
+    const savedColumns = this.getSavedVisibleColumnFields();
+    if (savedColumns) {
+      this.applySavedColumnVisibility(savedColumns);
     } else {
       this.resetVisibleColumnsToDefault();
     }
+    
+    // Handle tableCols changes (e.g., when switching tabs)
+    // if (changes.tableCols && !changes.tableCols.firstChange) {
+
+    // } else {
+      
+    // }
   }
 
   ngOnDestroy(): void {
@@ -229,58 +235,13 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
       return null;
     }
 
-    const rawValue = localStorage.getItem(this.visibleColumnStorageKey);
-    if (!rawValue) {
-      return null;
-    }
-
-    try {
-      const parsedValue = JSON.parse(rawValue);
-      if (parsedValue && typeof parsedValue === 'object' && !Array.isArray(parsedValue)) {
-        const savedAt = Number(parsedValue.savedAt);
-        const savedColumns = parsedValue.savedColumns;
-
-        if (!savedAt || !savedColumns) {
-          return null;
-        }
-
-        if (Date.now() - savedAt > this.visibleColumnsExpirationMs) {
-          localStorage.removeItem(this.visibleColumnStorageKey);
-          return null;
-        }
-
-        if (Array.isArray(savedColumns)) {
-          return savedColumns.map((item: any) => typeof item === 'string' ? item : item?.field).filter((field: any) => typeof field === 'string');
-        }
-      }
-
-      if (Array.isArray(parsedValue)) {
-        return parsedValue.map((item: any) => typeof item === 'string' ? item : item?.field).filter((field: any) => typeof field === 'string');
-      }
-    } catch (error) {
-      // Ignore invalid storage format
-    }
-
-    return null;
+    return this.sharedService.getJsonCookie<string[]>(this.visibleColumnStorageKey);
   }
 
-  private saveVisibleColumnPreferences(columnFields: string[]): void {
-    if (!this.visibleColumnStorageKey) {
-      return;
-    }
-
-    const payload = {
-      savedAt: Date.now(),
-      savedColumns: columnFields
-    };
-
-    localStorage.setItem(this.visibleColumnStorageKey, JSON.stringify(payload));
-  }
-
-  private applySavedColumnVisibility(savedColumnFields: string[]): void {
-    const savedFieldSet = new Set(savedColumnFields);
+  private applySavedColumnVisibility(savedFields: string[]): void {
+    const fieldSet = new Set(savedFields);
     this.tableCols.forEach(col => {
-      col.showColumn = savedFieldSet.has(col.field);
+      col.showColumn = fieldSet.has(col.field);
     });
     this.initializeColumnVisibility();
   }
@@ -291,11 +252,11 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
       col.showColumn = defaultVisibility !== false;
     });
 
-    this.initializeColumnVisibility();
-
     if (this.visibleColumnStorageKey) {
-      localStorage.removeItem(this.visibleColumnStorageKey);
+      this.sharedService.deleteCookie(this.visibleColumnStorageKey);
     }
+
+    this.initializeColumnVisibility();
   }
 
   private initializeColumnVisibility() {
@@ -323,7 +284,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
 
     if(this.visibleColumnStorageKey) {
       const selectedFields = this.visibleColumns.map(col => col.field).filter(field => !!field);
-      this.saveVisibleColumnPreferences(selectedFields);
+      this.sharedService.setJsonCookie(this.visibleColumnStorageKey, selectedFields);
     }
   }
 

--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -124,6 +124,8 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
   private tabelSearchString: string = '';
   private urlSearchTerm: string = '';
   private isHandlingDataUpdate: boolean = false;
+  private defaultColumnVisibility: Map<string, boolean> = new Map();
+  private readonly visibleColumnsExpirationMs: number = 12 * 60 * 60 * 1000;
 
   constructor(
     private sharedService: SharedService,
@@ -194,32 +196,16 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
       this.originalTableData = [...this.localTableData];
     }
 
-    if(localStorage.getItem(this.visibleColumnStorageKey)) {
-      const savedCols = JSON.parse(localStorage.getItem(this.visibleColumnStorageKey));
-
-      const statusMap = new Map();
-      savedCols.forEach(item => {
-          statusMap.set(item.field, true); 
-      });
-
-      this.tableCols.forEach(item1 => {
-          if (statusMap.has(item1.field)) {
-              item1.showColumn = true;
-          } else {
-            item1.showColumn = false;
-          }
-      });
-      this.initializeColumnVisibility();
-    } else {
-      this.initializeColumnVisibility();
+    if (changes.tableCols && this.tableCols && this.tableCols.length > 0) {
+      this.captureDefaultColumnVisibility();
     }
-    
-    // Handle tableCols changes (e.g., when switching tabs)
-    // if (changes.tableCols && !changes.tableCols.firstChange) {
 
-    // } else {
-      
-    // }
+    const savedColumnFields = this.getSavedVisibleColumnFields();
+    if (savedColumnFields) {
+      this.applySavedColumnVisibility(savedColumnFields);
+    } else {
+      this.resetVisibleColumnsToDefault();
+    }
   }
 
   ngOnDestroy(): void {
@@ -230,9 +216,95 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
+  private captureDefaultColumnVisibility(): void {
+    this.tableCols.forEach(col => {
+      if (!this.defaultColumnVisibility.has(col.field)) {
+        this.defaultColumnVisibility.set(col.field, col.showColumn !== false);
+      }
+    });
+  }
+
+  private getSavedVisibleColumnFields(): string[] | null {
+    if (!this.visibleColumnStorageKey) {
+      return null;
+    }
+
+    const rawValue = localStorage.getItem(this.visibleColumnStorageKey);
+    if (!rawValue) {
+      return null;
+    }
+
+    try {
+      const parsedValue = JSON.parse(rawValue);
+      if (parsedValue && typeof parsedValue === 'object' && !Array.isArray(parsedValue)) {
+        const savedAt = Number(parsedValue.savedAt);
+        const savedColumns = parsedValue.savedColumns;
+
+        if (!savedAt || !savedColumns) {
+          return null;
+        }
+
+        if (Date.now() - savedAt > this.visibleColumnsExpirationMs) {
+          localStorage.removeItem(this.visibleColumnStorageKey);
+          return null;
+        }
+
+        if (Array.isArray(savedColumns)) {
+          return savedColumns.map((item: any) => typeof item === 'string' ? item : item?.field).filter((field: any) => typeof field === 'string');
+        }
+      }
+
+      if (Array.isArray(parsedValue)) {
+        return parsedValue.map((item: any) => typeof item === 'string' ? item : item?.field).filter((field: any) => typeof field === 'string');
+      }
+    } catch (error) {
+      // Ignore invalid storage format
+    }
+
+    return null;
+  }
+
+  private saveVisibleColumnPreferences(columnFields: string[]): void {
+    if (!this.visibleColumnStorageKey) {
+      return;
+    }
+
+    const payload = {
+      savedAt: Date.now(),
+      savedColumns: columnFields
+    };
+
+    localStorage.setItem(this.visibleColumnStorageKey, JSON.stringify(payload));
+  }
+
+  private applySavedColumnVisibility(savedColumnFields: string[]): void {
+    const savedFieldSet = new Set(savedColumnFields);
+    this.tableCols.forEach(col => {
+      col.showColumn = savedFieldSet.has(col.field);
+    });
+    this.initializeColumnVisibility();
+  }
+
+  private resetVisibleColumnsToDefault(): void {
+    this.tableCols.forEach(col => {
+      const defaultVisibility = this.defaultColumnVisibility.get(col.field);
+      col.showColumn = defaultVisibility !== false;
+    });
+
+    this.initializeColumnVisibility();
+
+    if (this.visibleColumnStorageKey) {
+      localStorage.removeItem(this.visibleColumnStorageKey);
+    }
+  }
+
   private initializeColumnVisibility() {
     // Simply set visibleColumns to all columns that should be visible
     this.visibleColumns = this.tableCols.filter(col => col.showColumn !== false);
+  }
+
+  public resetVisibleColumns(): void {
+    this.resetVisibleColumnsToDefault();
   }
 
   toggleVisible(e: any) {
@@ -250,8 +322,8 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
     });
 
     if(this.visibleColumnStorageKey) {
-      localStorage.setItem(this.visibleColumnStorageKey, JSON.stringify(this.visibleColumns));
-      // localStorage.setItem(this.visibleColumnStorageKey, JSON.stringify(this.tableCols));
+      const selectedFields = this.visibleColumns.map(col => col.field).filter(field => !!field);
+      this.saveVisibleColumnPreferences(selectedFields);
     }
   }
 

--- a/src/app/services/shared/cookie.service.ts
+++ b/src/app/services/shared/cookie.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CookieService {
+  public static readonly DEFAULT_EXPIRE_HOURS = 12;
+  public static readonly DEFAULT_PATH = '';
+
+  public getCookie(name: string): string {
+    const ca: Array<string> = document.cookie.split(';');
+    const cookieName = `${name}=`;
+    let c: string;
+
+    for (let i = 0; i < ca.length; i += 1) {
+      c = ca[i].replace(/^\s+/g, '');
+      if (c.indexOf(cookieName) === 0) {
+        return c.substring(cookieName.length, c.length);
+      }
+    }
+    return '';
+  }
+
+  public setCookie(name: string, value: string, expireHours: number = CookieService.DEFAULT_EXPIRE_HOURS, path: string = CookieService.DEFAULT_PATH) {
+    const d: Date = new Date();
+    d.setTime(d.getTime() + expireHours * 60 * 60 * 1000);
+    const expires: string = `expires=${d.toUTCString()}`;
+    const cpath: string = path ? `; path=${path}` : '';
+    document.cookie = `${name}=${value}; ${expires}${cpath}`;
+  }
+
+  public deleteCookie(name: string, path: string = CookieService.DEFAULT_PATH): void {
+    this.setCookie(name, '', -1, path);
+  }
+
+  public setJsonCookie<T>(name: string, value: T, expireHours: number = CookieService.DEFAULT_EXPIRE_HOURS, path: string = CookieService.DEFAULT_PATH): void {
+    this.setCookie(name, JSON.stringify(value), expireHours, path);
+  }
+
+  public getJsonCookie<T>(name: string): T | null {
+    const raw = this.getCookie(name);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as T;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  public getCookies() {
+    const pairs = document.cookie.split(';');
+    const cookies = {} as any;
+    for (let i = 0; i < pairs.length; i++) {
+      const pair = pairs[i].split('=');
+      cookies[(pair[0] + '').trim()] = unescape(pair.slice(1).join('='));
+    }
+    return cookies;
+  }
+}

--- a/src/app/services/shared/shared.service.ts
+++ b/src/app/services/shared/shared.service.ts
@@ -9,7 +9,6 @@ import jwtDecode from 'jwt-decode';
 import { HttpClient } from '@angular/common/http';
 import { set } from 'd3';
 import { BehaviorSubject } from 'rxjs';
-import { CookieService } from './cookie.service';
 import { DataDictionary } from '@api/models/data-dictionary.model';
 
 // Declare jQuery symbol
@@ -47,8 +46,7 @@ export class SharedService {
     private globals: Globals,
     private location: Location,
     private router: Router,
-    private http: HttpClient,
-    private cookieService: CookieService
+    private http: HttpClient
     ) {
   }
 
@@ -411,30 +409,6 @@ export class SharedService {
   };
 
   // Cookie helpers delegate to CookieService
-  public setCookie(name: string, value: string, expireHours: number, path: string = '') {
-    this.cookieService.setCookie(name, value, expireHours, path);
-  }
-
-  public getCookie(name: string): string {
-    return this.cookieService.getCookie(name);
-  }
-
-  public deleteCookie(name: string, path: string = ''): void {
-    this.cookieService.deleteCookie(name, path);
-  }
-
-  public setJsonCookie<T>(name: string, value: T, expireHours: number = SharedService.COOKIE_EXPIRE_HOURS, path: string = ''): void {
-    this.cookieService.setJsonCookie(name, value, expireHours, path);
-  }
-
-  public getJsonCookie<T>(name: string): T | null {
-    return this.cookieService.getJsonCookie<T>(name);
-  }
-
-  public getCookies() {
-    return this.cookieService.getCookies();
-  }
-
   public enableStickyHeader(tableComponentId: string, closestScrollableClass: string = '.content-body') {
     $('#'+tableComponentId).floatThead({
       responsiveContainer: function($table) {

--- a/src/app/services/shared/shared.service.ts
+++ b/src/app/services/shared/shared.service.ts
@@ -18,6 +18,7 @@ declare var $: any;
   providedIn: 'root'
 })
 export class SharedService {
+  public static readonly COOKIE_EXPIRE_HOURS = 12;
 
   // Sidebar Toggle Service
   toggleEmitter = new EventEmitter();
@@ -437,6 +438,24 @@ export class SharedService {
     const expires: string = `expires=${d.toUTCString()}`;
     const cpath: string = path ? `; path=${path}` : '';
     document.cookie = `${name}=${value}; ${expires}${cpath}`;
+  }
+
+  public setJsonCookie<T>(name: string, value: T, expireHours: number = SharedService.COOKIE_EXPIRE_HOURS, path: string = ''): void {
+    const expireDays = expireHours / 24;
+    this.setCookie(name, JSON.stringify(value), expireDays, path);
+  }
+
+  public getJsonCookie<T>(name: string): T | null {
+    const raw = this.getCookie(name);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as T;
+    } catch (error) {
+      return null;
+    }
   }
 
   // get a list of all cookies

--- a/src/app/services/shared/shared.service.ts
+++ b/src/app/services/shared/shared.service.ts
@@ -9,6 +9,7 @@ import jwtDecode from 'jwt-decode';
 import { HttpClient } from '@angular/common/http';
 import { set } from 'd3';
 import { BehaviorSubject } from 'rxjs';
+import { CookieService } from './cookie.service';
 import { DataDictionary } from '@api/models/data-dictionary.model';
 
 // Declare jQuery symbol
@@ -46,7 +47,8 @@ export class SharedService {
     private globals: Globals,
     private location: Location,
     private router: Router,
-    private http: HttpClient
+    private http: HttpClient,
+    private cookieService: CookieService
     ) {
   }
 
@@ -408,65 +410,29 @@ export class SharedService {
     this.location.replaceState(`${normalizedURL}/${row[IDname]}`);
   };
 
-  // cookies functions ---------------------------------------
+  // Cookie helpers delegate to CookieService
+  public setCookie(name: string, value: string, expireHours: number, path: string = '') {
+    this.cookieService.setCookie(name, value, expireHours, path);
+  }
 
-  // get a cookie by name
-  public getCookie(name: string) {
-    const ca: Array<string> = document.cookie.split(';');
-    const caLen: number = ca.length;
-    const cookieName = `${name}=`;
-    let c: string;
-  
-    for (let i = 0; i < caLen; i += 1) {
-      c = ca[i].replace(/^\s+/g, '');
-      if (c.indexOf(cookieName) === 0) {
-        return c.substring(cookieName.length, c.length);
-      }
-    }
-    return '';
+  public getCookie(name: string): string {
+    return this.cookieService.getCookie(name);
   }
-  
-  // delete a cookie by name
-  public deleteCookie(name) {
-    this.setCookie(name, '', -1);
-  }
-  
-  // set a cookie
-  public setCookie(name: string, value: string, expireDays: number, path: string = '') {
-    const d: Date = new Date();
-    d.setTime(d.getTime() + expireDays * 24 * 60 * 60 * 1000);
-    const expires: string = `expires=${d.toUTCString()}`;
-    const cpath: string = path ? `; path=${path}` : '';
-    document.cookie = `${name}=${value}; ${expires}${cpath}`;
+
+  public deleteCookie(name: string, path: string = ''): void {
+    this.cookieService.deleteCookie(name, path);
   }
 
   public setJsonCookie<T>(name: string, value: T, expireHours: number = SharedService.COOKIE_EXPIRE_HOURS, path: string = ''): void {
-    const expireDays = expireHours / 24;
-    this.setCookie(name, JSON.stringify(value), expireDays, path);
+    this.cookieService.setJsonCookie(name, value, expireHours, path);
   }
 
   public getJsonCookie<T>(name: string): T | null {
-    const raw = this.getCookie(name);
-    if (!raw) {
-      return null;
-    }
-
-    try {
-      return JSON.parse(raw) as T;
-    } catch (error) {
-      return null;
-    }
+    return this.cookieService.getJsonCookie<T>(name);
   }
 
-  // get a list of all cookies
   public getCookies() {
-    const pairs = document.cookie.split(';');
-    const cookies = {};
-    for (let i = 0; i < pairs.length; i++) {
-      const pair = pairs[i].split('=');
-      cookies[(pair[0] + '').trim()] = unescape(pair.slice(1).join('='));
-    }
-    return cookies;
+    return this.cookieService.getCookies();
   }
 
   public enableStickyHeader(tableComponentId: string, closestScrollableClass: string = '.content-body') {


### PR DESCRIPTION
…n, Added expiry-aware persistence for visible columns.

Isuue Ticket:
https://github.com/GSA/GEAR3/issues/900

Exisitng Flow:
Report tables already use visibleColumnStorageKey to store visible column state.toggleVisible() updates visibleColumns and persists the current selection. On component load, saved preferences are read and applied to tableCols. Default visibility is missed from each column’s showColumn setting.

RootCause:
The table component persisted user-selected visible columns in localStorage via visibleColumnStorageKey. Saved column list had no expiry, so custom table layouts stayed active permanently. As a result, users could reopen the same report later and unexpectedly see too many columns and horizontal scrolling.

Solution/fix:
Added expiry-aware persistence for visible columns:
Saved state now stores: savedAt, savedColumns
On load, the component ignores saved settings older than 12 hours.
Also. Added a manual reset button next to the Add/Remove Columns dropdown, Resets the current table back to its default visible columns. Clears the persisted storage key for that report.

Build Result:
<img width="869" height="301" alt="image" src="https://github.com/user-attachments/assets/ac550f2f-9da4-4ac8-81dc-673558ce4417" />

Test Result:
<img width="1268" height="576" alt="image" src="https://github.com/user-attachments/assets/aeb99443-6231-497c-b69b-74e09c885200" />
<img width="1272" height="543" alt="image" src="https://github.com/user-attachments/assets/471be1f3-36e4-4cf5-9f5d-330015605e18" />
<img width="1264" height="581" alt="image" src="https://github.com/user-attachments/assets/aeb916e3-636b-4700-bf4a-f52ce7500689" />


