### PR TITLE
Reduced Description and made description fully visible also removed the line-clamp truncation

### DIFF
--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.html
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.html
@@ -18,11 +18,10 @@
     </div>
   </div>
   <div class="capabilities-definition-container">
-    <p #definitionText class="capabilities-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+    <p class="capabilities-definition-text">
       This model categorizes GSA’s business functions and services using a standard framework rather than organizational charts. By standardizing these functions, it promotes collaboration, shared services, and IT solution reuse. It is most effective when used for business analysis, design, and decision-making to improve agency performance. (<a href='https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/egov_docs/fea_v2.pdf' target='_blank' rel='noopener'>FEAF pg 30</a>)
     </p>
-      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
-    </div>
+  </div>
     <div class="capabilities-data-container">
     <!-- Detail Card -->
     <div id="capDetail" class="card col-6 h-30">

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.html
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.html
@@ -18,15 +18,10 @@
     </div>
   </div>
   <div class="capabilities-definition-container">
-    <p class="capabilities-definition-text" [ngClass]="{'expanded' : defExpanded}">A classification taxonomy used to describe the business
-      functions and services at GSA. By describing GSA using standard business functions 
-      rather than an organizational view, this taxonomy promotes collaboration, shared services, 
-      and solution reuse in agency IT portfolios and inter-agency Lines of Business. While this taxonomy 
-      provides a standardized way of classifying government functions, its true value is realized when 
-      it is effectively used in business analysis, design, and decision support that help to improve the performance of GSA. 
-      (<a href='https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/egov_docs/fea_v2.pdf' target='_blank' rel='noopener'>FEAF pg 30</a>)
+    <p #definitionText class="capabilities-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+      This model categorizes GSA’s business functions and services using a standard framework rather than organizational charts. By standardizing these functions, it promotes collaboration, shared services, and IT solution reuse. It is most effective when used for business analysis, design, and decision-making to improve agency performance. (<a href='https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/egov_docs/fea_v2.pdf' target='_blank' rel='noopener'>FEAF pg 30</a>)
     </p>
-      <app-button [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
+      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
     </div>
     <div class="capabilities-data-container">
     <!-- Detail Card -->

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.scss
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.scss
@@ -59,11 +59,14 @@
        border-radius: 0.3rem;
 
       & .capabilities-definition-text {
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          -webkit-box-orient: vertical;  
-          overflow: hidden;
           margin-bottom: .25rem;
+
+          &.truncated {
+              display: -webkit-box;
+              -webkit-line-clamp: 4;
+              -webkit-box-orient: vertical;  
+              overflow: hidden;
+          }
 
           &.expanded {
               -webkit-line-clamp: none;

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.scss
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.scss
@@ -61,6 +61,17 @@
       & .capabilities-definition-text {
           margin-bottom: .25rem;
 
+          a {
+              color: #005ea2;
+              text-decoration: underline;
+
+              &:hover,
+              &:focus {
+                  color: #1a4480;
+                  text-decoration-thickness: 2px;
+              }
+          }
+
           &.truncated {
               display: -webkit-box;
               -webkit-line-clamp: 4;

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, AfterViewInit, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
@@ -26,14 +26,16 @@ interface CapTree {
     styleUrls: ['./capabilities-model.component.scss'],
     standalone: false
 })
-export class CapabilitiesModelComponent implements OnInit {
-  @ViewChild('busCapGraph') public graphContainer: ElementRef;
+export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
+  @ViewChild('busCapGraph') public graphContainer: ElementRef | undefined;
+  @ViewChild('definitionText') public definitionText: ElementRef | undefined;
   private caps: any[] = [];
   private root: any = {};
   private rootCap: string = 'Manage GSA';
   private capTree: any = {};
   public highlightColor: string = '#ff4136';
   public defExpanded: boolean = false;
+  public showViewMore: boolean = false;
 
   // Variables to store mouse position and dragging status
   private dragging = false;
@@ -50,8 +52,8 @@ export class CapabilitiesModelComponent implements OnInit {
   // Save selected node id
   private selectedCap: any;
 
-  public searchKey: string;
-  private finalSearchPath;
+  public searchKey: string = '';
+  private finalSearchPath: any = null;
 
   constructor(
     private apiService: ApiService,
@@ -61,7 +63,8 @@ export class CapabilitiesModelComponent implements OnInit {
     private tableService: TableService,
     private titleService: Title,
     private elementRef: ElementRef,
-    private router: Router
+    private router: Router,
+    private cdRef: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
@@ -94,6 +97,11 @@ export class CapabilitiesModelComponent implements OnInit {
     capDetail.on('mousedown', (event) => this.dragStart(event));
     d3.select(document).on('mousemove', (event) => this.drag(event));
     d3.select(document).on('mouseup', (event) => this.dragEnd(event));
+
+    setTimeout(() => {
+      this.updateViewMoreVisibility();
+      this.cdRef.detectChanges();
+    });
   }
 
   // Create Capability Model Graph
@@ -689,5 +697,25 @@ export class CapabilitiesModelComponent implements OnInit {
 
     public onViewAll(): void {
       this.defExpanded = !this.defExpanded;
+    }
+
+    private updateViewMoreVisibility(): void {
+      if (!this.definitionText || !this.definitionText.nativeElement) {
+        this.showViewMore = false;
+        return;
+      }
+
+      const el = this.definitionText.nativeElement as HTMLElement;
+      this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
+    }
+
+    private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
+      if (!text || !text.trim()) {
+        return false;
+      }
+
+      const words = text.trim().split(/\s+/).length;
+      const wordThreshold = 40;
+      return words > wordThreshold || isOverflow;
     }
 }

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
@@ -714,8 +714,7 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
         return false;
       }
 
-      const words = text.trim().split(/\s+/).length;
-      const wordThreshold = 40;
-      return words > wordThreshold || isOverflow;
+      // Only show view-more when the rendered text is actually truncated
+      return isOverflow;
     }
 }

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-import { Component, ElementRef, OnInit, AfterViewInit, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, ElementRef, OnInit, AfterViewInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
@@ -28,14 +28,11 @@ interface CapTree {
 })
 export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
   @ViewChild('busCapGraph') public graphContainer: ElementRef | undefined;
-  @ViewChild('definitionText') public definitionText: ElementRef | undefined;
   private caps: any[] = [];
   private root: any = {};
   private rootCap: string = 'Manage GSA';
   private capTree: any = {};
   public highlightColor: string = '#ff4136';
-  public defExpanded: boolean = false;
-  public showViewMore: boolean = false;
 
   // Variables to store mouse position and dragging status
   private dragging = false;
@@ -63,8 +60,7 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
     private tableService: TableService,
     private titleService: Title,
     private elementRef: ElementRef,
-    private router: Router,
-    private cdRef: ChangeDetectorRef
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -98,10 +94,6 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
     d3.select(document).on('mousemove', (event) => this.drag(event));
     d3.select(document).on('mouseup', (event) => this.dragEnd(event));
 
-    setTimeout(() => {
-      this.updateViewMoreVisibility();
-      this.cdRef.detectChanges();
-    });
   }
 
   // Create Capability Model Graph
@@ -695,26 +687,4 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
       d3.select(this.elementRef.nativeElement).select('#capDetail').classed('grabbing', false);
     }
 
-    public onViewAll(): void {
-      this.defExpanded = !this.defExpanded;
-    }
-
-    private updateViewMoreVisibility(): void {
-      if (!this.definitionText || !this.definitionText.nativeElement) {
-        this.showViewMore = false;
-        return;
-      }
-
-      const el = this.definitionText.nativeElement as HTMLElement;
-      this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
-    }
-
-    private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
-      if (!text || !text.trim()) {
-        return false;
-      }
-
-      // Only show view-more when the rendered text is actually truncated
-      return isOverflow;
-    }
-}
+  }

--- a/src/app/views/enterprise/capabilities/capabilities.component.html
+++ b/src/app/views/enterprise/capabilities/capabilities.component.html
@@ -12,14 +12,10 @@
     </div>
   </div>
   <div class="capabilities-definition-container">
-    <p class="capabilities-definition-text" [ngClass]="{'expanded' : defExpanded}">A classification taxonomy used to describe the business
-      functions and services at GSA. By describing GSA using standard business functions
-      rather than an organizational view, this taxonomy promotes collaboration, shared services,
-      and solution reuse in agency IT portfolios and inter-agency Lines of Business. While this taxonomy
-      provides a standardized way of classifying government functions, its true value is realized when
-      it is effectively used in business analysis, design, and decision support that help to improve the performance of GSA.
-      (<a href='https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/egov_docs/fea_v2.pdf' target='_blank' rel='noopener'>FEAF pg 30</a>)</p>
-      <app-button [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
+    <p #definitionText class="capabilities-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+      This model categorizes GSA’s business functions and services using a standard framework rather than organizational charts. By standardizing these functions, it promotes collaboration, shared services, and IT solution reuse. It is most effective when used for business analysis, design, and decision-making to improve agency performance. (<a href='https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/egov_docs/fea_v2.pdf' target='_blank' rel='noopener'>FEAF pg 30</a>)
+    </p>
+      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
     </div>
     <div class="capabilities-data-container">
       <app-table visibleColumnStorageKey="capabilities-report" defaultSortField="Name" [tableCols]="tableCols" [attrDefs]="attrDefinitions" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" (rowClickEvent)="onRowClick($event)"></app-table>

--- a/src/app/views/enterprise/capabilities/capabilities.component.html
+++ b/src/app/views/enterprise/capabilities/capabilities.component.html
@@ -12,10 +12,9 @@
     </div>
   </div>
   <div class="capabilities-definition-container">
-    <p #definitionText class="capabilities-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+    <p class="capabilities-definition-text">
       This model categorizes GSA’s business functions and services using a standard framework rather than organizational charts. By standardizing these functions, it promotes collaboration, shared services, and IT solution reuse. It is most effective when used for business analysis, design, and decision-making to improve agency performance. (<a href='https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/egov_docs/fea_v2.pdf' target='_blank' rel='noopener'>FEAF pg 30</a>)
     </p>
-      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
     </div>
     <div class="capabilities-data-container">
       <app-table visibleColumnStorageKey="capabilities-report" defaultSortField="Name" [tableCols]="tableCols" [attrDefs]="attrDefinitions" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" (rowClickEvent)="onRowClick($event)"></app-table>

--- a/src/app/views/enterprise/capabilities/capabilities.component.scss
+++ b/src/app/views/enterprise/capabilities/capabilities.component.scss
@@ -23,6 +23,17 @@
         & .capabilities-definition-text {
             margin-bottom: 5px;
 
+            a {
+                color: #005ea2;
+                text-decoration: underline;
+
+                &:hover,
+                &:focus {
+                    color: #1a4480;
+                    text-decoration-thickness: 2px;
+                }
+            }
+
             &.truncated {
                 display: -webkit-box;
                 -webkit-line-clamp: 4;

--- a/src/app/views/enterprise/capabilities/capabilities.component.scss
+++ b/src/app/views/enterprise/capabilities/capabilities.component.scss
@@ -21,11 +21,14 @@
          border-radius: 0.3rem;
 
         & .capabilities-definition-text {
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;  
-            overflow: hidden;
-            margin-bottom: .25rem;
+            margin-bottom: 5px;
+
+            &.truncated {
+                display: -webkit-box;
+                -webkit-line-clamp: 4;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+            }
 
             &.expanded {
                 -webkit-line-clamp: none;

--- a/src/app/views/enterprise/capabilities/capabilities.component.ts
+++ b/src/app/views/enterprise/capabilities/capabilities.component.ts
@@ -133,9 +133,8 @@ export class CapabilitiesComponent implements OnInit, AfterViewInit {
       return false;
     }
 
-    const words = text.trim().split(/\s+/).length;
-    const wordThreshold = 40;
-    return words > wordThreshold || isOverflow;
+    // Only show view-more when the rendered text is actually truncated
+    return isOverflow;
   }
 
   public onRowClick(e: any) {

--- a/src/app/views/enterprise/capabilities/capabilities.component.ts
+++ b/src/app/views/enterprise/capabilities/capabilities.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -17,8 +17,10 @@ import { DataDictionary } from '@api/models/data-dictionary.model';
     styleUrls: ['./capabilities.component.scss'],
     standalone: false
 })
-export class CapabilitiesComponent implements OnInit {
+export class CapabilitiesComponent implements OnInit, AfterViewInit {
+  @ViewChild('definitionText') public definitionText: ElementRef | undefined;
   public defExpanded: boolean = false;
+  public showViewMore: boolean = false;
 
   public attrDefinitions: DataDictionary[] = [];
 
@@ -34,7 +36,8 @@ export class CapabilitiesComponent implements OnInit {
     public sharedService: SharedService,
     private tableService: TableService,
     private titleService: Title,
-    private router: Router
+    private router: Router,
+    private cdRef: ChangeDetectorRef
   ) {
     this.modalService.currentCap.subscribe((row) => (this.row = row));
   }
@@ -106,6 +109,33 @@ export class CapabilitiesComponent implements OnInit {
 
   public onViewAll(): void {
     this.defExpanded = !this.defExpanded;
+  }
+
+  public ngAfterViewInit(): void {
+    setTimeout(() => {
+      this.updateViewMoreVisibility();
+      this.cdRef.detectChanges();
+    });
+  }
+
+  private updateViewMoreVisibility(): void {
+    if (!this.definitionText || !this.definitionText.nativeElement) {
+      this.showViewMore = false;
+      return;
+    }
+
+    const el = this.definitionText.nativeElement as HTMLElement;
+    this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
+  }
+
+  private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
+    if (!text || !text.trim()) {
+      return false;
+    }
+
+    const words = text.trim().split(/\s+/).length;
+    const wordThreshold = 40;
+    return words > wordThreshold || isOverflow;
   }
 
   public onRowClick(e: any) {

--- a/src/app/views/enterprise/capabilities/capabilities.component.ts
+++ b/src/app/views/enterprise/capabilities/capabilities.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -17,11 +17,7 @@ import { DataDictionary } from '@api/models/data-dictionary.model';
     styleUrls: ['./capabilities.component.scss'],
     standalone: false
 })
-export class CapabilitiesComponent implements OnInit, AfterViewInit {
-  @ViewChild('definitionText') public definitionText: ElementRef | undefined;
-  public defExpanded: boolean = false;
-  public showViewMore: boolean = false;
-
+export class CapabilitiesComponent implements OnInit {
   public attrDefinitions: DataDictionary[] = [];
 
   row: Object = <any>{};
@@ -36,8 +32,7 @@ export class CapabilitiesComponent implements OnInit, AfterViewInit {
     public sharedService: SharedService,
     private tableService: TableService,
     private titleService: Title,
-    private router: Router,
-    private cdRef: ChangeDetectorRef
+    private router: Router
   ) {
     this.modalService.currentCap.subscribe((row) => (this.row = row));
   }
@@ -105,36 +100,6 @@ export class CapabilitiesComponent implements OnInit, AfterViewInit {
 
   public isLoggedIn(): boolean {
     return this.sharedService.loggedIn;
-  }
-
-  public onViewAll(): void {
-    this.defExpanded = !this.defExpanded;
-  }
-
-  public ngAfterViewInit(): void {
-    setTimeout(() => {
-      this.updateViewMoreVisibility();
-      this.cdRef.detectChanges();
-    });
-  }
-
-  private updateViewMoreVisibility(): void {
-    if (!this.definitionText || !this.definitionText.nativeElement) {
-      this.showViewMore = false;
-      return;
-    }
-
-    const el = this.definitionText.nativeElement as HTMLElement;
-    this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
-  }
-
-  private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
-    if (!text || !text.trim()) {
-      return false;
-    }
-
-    // Only show view-more when the rendered text is actually truncated
-    return isOverflow;
   }
 
   public onRowClick(e: any) {

--- a/src/app/views/enterprise/website-service-category/website-service-category.component.html
+++ b/src/app/views/enterprise/website-service-category/website-service-category.component.html
@@ -4,11 +4,10 @@
     <app-page-help-button></app-page-help-button>
   </div>
   <div class="website-categories-definition-container">
-    <p class="website-categories-definition-text" [ngClass]="{'expanded' : defExpanded}">Website Service Categories draw connections between sites that serve similar themes. For instance, GSA supports both travel policy 
-      (OGP) and travel services (FAS) and maintains several websites that reference one or both. All teams across GSA that manage or reference
-       a common content topic area (such as travel) need to communicate and coordinate around these service themes in order to provide a consistent 
-       experience to customers across all channels.</p>
-      <app-button [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
+    <p #definitionText class="website-categories-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+      Website Service Categories link sites with shared themes. For example, GSA oversees travel through both policy and services. To provide a consistent experience, teams managing shared topics must coordinate closely.
+    </p>
+      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
   </div>
   <div class="website-categories-data-container">
     <app-table visibleColumnStorageKey="websites-website-categories" defaultSortField="name" [tableCols]="tableCols" [attrDefs]="attrDefinitions" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" (rowClickEvent)="onRowClick($event)"></app-table>

--- a/src/app/views/enterprise/website-service-category/website-service-category.component.html
+++ b/src/app/views/enterprise/website-service-category/website-service-category.component.html
@@ -4,10 +4,9 @@
     <app-page-help-button></app-page-help-button>
   </div>
   <div class="website-categories-definition-container">
-    <p #definitionText class="website-categories-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+    <p class="website-categories-definition-text">
       Website Service Categories link sites with shared themes. For example, GSA oversees travel through both policy and services. To provide a consistent experience, teams managing shared topics must coordinate closely.
     </p>
-      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
   </div>
   <div class="website-categories-data-container">
     <app-table visibleColumnStorageKey="websites-website-categories" defaultSortField="name" [tableCols]="tableCols" [attrDefs]="attrDefinitions" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" (rowClickEvent)="onRowClick($event)"></app-table>

--- a/src/app/views/enterprise/website-service-category/website-service-category.component.scss
+++ b/src/app/views/enterprise/website-service-category/website-service-category.component.scss
@@ -20,11 +20,14 @@
          border-radius: 0.3rem;
 
         & .website-categories-definition-text {
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;  
-            overflow: hidden;
-             margin-bottom: 5px;
+            margin-bottom: 5px;
+
+            &.truncated {
+                display: -webkit-box;
+                -webkit-line-clamp: 4;
+                -webkit-box-orient: vertical;  
+                overflow: hidden;
+            }
 
             &.expanded {
                 -webkit-line-clamp: none;

--- a/src/app/views/enterprise/website-service-category/website-service-category.component.scss
+++ b/src/app/views/enterprise/website-service-category/website-service-category.component.scss
@@ -22,6 +22,17 @@
         & .website-categories-definition-text {
             margin-bottom: 5px;
 
+            a {
+                color: #005ea2;
+                text-decoration: underline;
+
+                &:hover,
+                &:focus {
+                    color: #1a4480;
+                    text-decoration-thickness: 2px;
+                }
+            }
+
             &.truncated {
                 display: -webkit-box;
                 -webkit-line-clamp: 4;

--- a/src/app/views/enterprise/website-service-category/website-service-category.component.ts
+++ b/src/app/views/enterprise/website-service-category/website-service-category.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
@@ -16,14 +16,10 @@ import { DataDictionary } from '@api/models/data-dictionary.model';
     styleUrls: ['./website-service-category.component.scss'],
     standalone: false
 })
-export class WebsiteServiceCategoryComponent implements OnInit, AfterViewInit {
-  @ViewChild('definitionText') public definitionText: ElementRef;
-  public defExpanded: boolean = false;
-  public showViewMore: boolean = false;
-
+export class WebsiteServiceCategoryComponent implements OnInit {
   public attrDefinitions: DataDictionary[] = [];
 
-  row: Object = <any>{};
+  row: any = {};
 
   constructor(
     private apiService: ApiService,
@@ -32,8 +28,7 @@ export class WebsiteServiceCategoryComponent implements OnInit, AfterViewInit {
     private sharedService: SharedService,
     private tableService: TableService,
     private titleService: Title,
-    private router: Router,
-    private cdRef: ChangeDetectorRef
+    private router: Router
   ) {
     this.modalService.currentWebsiteServiceCategory.subscribe(
       (row) => (this.row = row)
@@ -88,36 +83,6 @@ export class WebsiteServiceCategoryComponent implements OnInit, AfterViewInit {
           });
       }
     });
-  }
-
-  public onViewAll(): void {
-    this.defExpanded = !this.defExpanded;
-  }
-
-  public ngAfterViewInit(): void {
-    setTimeout(() => {
-      this.updateViewMoreVisibility();
-      this.cdRef.detectChanges();
-    });
-  }
-
-  private updateViewMoreVisibility(): void {
-    if (!this.definitionText || !this.definitionText.nativeElement) {
-      this.showViewMore = false;
-      return;
-    }
-
-    const el = this.definitionText.nativeElement as HTMLElement;
-    this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
-  }
-
-  private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
-    if (!text || !text.trim()) {
-      return false;
-    }
-
-    // Only show view-more when the rendered text is actually truncated
-    return isOverflow;
   }
 
   public onRowClick(e: any) {

--- a/src/app/views/enterprise/website-service-category/website-service-category.component.ts
+++ b/src/app/views/enterprise/website-service-category/website-service-category.component.ts
@@ -116,9 +116,8 @@ export class WebsiteServiceCategoryComponent implements OnInit, AfterViewInit {
       return false;
     }
 
-    const words = text.trim().split(/\s+/).length;
-    const wordThreshold = 40;
-    return words > wordThreshold || isOverflow;
+    // Only show view-more when the rendered text is actually truncated
+    return isOverflow;
   }
 
   public onRowClick(e: any) {

--- a/src/app/views/enterprise/website-service-category/website-service-category.component.ts
+++ b/src/app/views/enterprise/website-service-category/website-service-category.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
@@ -16,8 +16,10 @@ import { DataDictionary } from '@api/models/data-dictionary.model';
     styleUrls: ['./website-service-category.component.scss'],
     standalone: false
 })
-export class WebsiteServiceCategoryComponent implements OnInit {
+export class WebsiteServiceCategoryComponent implements OnInit, AfterViewInit {
+  @ViewChild('definitionText') public definitionText: ElementRef;
   public defExpanded: boolean = false;
+  public showViewMore: boolean = false;
 
   public attrDefinitions: DataDictionary[] = [];
 
@@ -30,7 +32,8 @@ export class WebsiteServiceCategoryComponent implements OnInit {
     private sharedService: SharedService,
     private tableService: TableService,
     private titleService: Title,
-    private router: Router
+    private router: Router,
+    private cdRef: ChangeDetectorRef
   ) {
     this.modalService.currentWebsiteServiceCategory.subscribe(
       (row) => (this.row = row)
@@ -89,6 +92,33 @@ export class WebsiteServiceCategoryComponent implements OnInit {
 
   public onViewAll(): void {
     this.defExpanded = !this.defExpanded;
+  }
+
+  public ngAfterViewInit(): void {
+    setTimeout(() => {
+      this.updateViewMoreVisibility();
+      this.cdRef.detectChanges();
+    });
+  }
+
+  private updateViewMoreVisibility(): void {
+    if (!this.definitionText || !this.definitionText.nativeElement) {
+      this.showViewMore = false;
+      return;
+    }
+
+    const el = this.definitionText.nativeElement as HTMLElement;
+    this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
+  }
+
+  private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
+    if (!text || !text.trim()) {
+      return false;
+    }
+
+    const words = text.trim().split(/\s+/).length;
+    const wordThreshold = 40;
+    return words > wordThreshold || isOverflow;
   }
 
   public onRowClick(e: any) {

--- a/src/app/views/security/fisma/fisma.component.html
+++ b/src/app/views/security/fisma/fisma.component.html
@@ -4,10 +4,7 @@
     <app-page-help-button></app-page-help-button>
   </div>
   <div class="fisma-inventory-definition-container">
-    <p class="fisma-inventory-definition-text">A FISMA system represents a logical boundary for which common
-       security controls and policies are applied to a grouping of related assets (e.g., networks, devices, and people) to accomplish some mission 
-       or business objective. It is informed by security artifacts, such as a system security and privacy plan (SSPP).
-        (<a href='https://csrc.nist.gov/projects/risk-management/fisma-background' target='_blank' rel='noopener'>Link</a>)</p>
+    <p class="fisma-inventory-definition-text">A FISMA system groups related assets—such as networks, devices, and people—that share common security controls and policies to support a specific business mission. These systems are defined by security documents like a System Security and Privacy Plan (SSPP). (<a href='https://csrc.nist.gov/projects/risk-management/fisma-background' target='_blank' rel='noopener'>Link</a>)</p>
   </div>
   <div class="fisma-inventory-data-container">
     <app-table visibleColumnStorageKey="fisma-report" defaultSortField="Name" [tableCols]="tableCols" [showToolbar]="true" [attrDefs]="attrDefinitions" [showPagination]="true" reportStyle="neutral" (rowClickEvent)="onRowClick($event)">

--- a/src/app/views/strategy/investments/investments.component.html
+++ b/src/app/views/strategy/investments/investments.component.html
@@ -4,14 +4,13 @@
     <app-page-help-button></app-page-help-button>
   </div>
   <div class="it-investments-definition-container">
-    <p class="it-investments-definition-text" [ngClass]="{'expanded' : defExpanded}">An IT investment is a resource expenditure 
+    <p class="it-investments-definition-text">An IT investment is a resource expenditure 
       to address mission delivery and management support. This includes the development, modernization, enhancement, maintenance,
        and operation of IT assets or functional groups in a production environment. This data is imported from
         <a href="https://access-management-gsa.folio.ecpic.gov/Authentication" target="_blank" rel="noopener">Folio</a>,
          a Capital Planning and Investment Control (CPIC) solution that helps Agencies manage their IT Portfolios and submit 
          required data to the OMB IT Dashboard.
     </p>
-      <app-button [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
   </div>
   <div class="investments-graph-container">
     <span id="investVizText" tabindex="0"

--- a/src/app/views/strategy/investments/investments.component.scss
+++ b/src/app/views/strategy/investments/investments.component.scss
@@ -20,15 +20,19 @@
          border-radius: 0.3rem;
 
         & .it-investments-definition-text {
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;  
-            overflow: hidden;
+            display: block;
+            overflow: visible;
             margin-bottom: .5rem;
 
-            &.expanded {
-                -webkit-line-clamp: none;
-                overflow: visible;
+            a {
+                color: #005ea2;
+                text-decoration: underline;
+
+                &:hover,
+                &:focus {
+                    color: #1a4480;
+                    text-decoration-thickness: 2px;
+                }
             }
         }
     }

--- a/src/app/views/strategy/investments/investments.component.ts
+++ b/src/app/views/strategy/investments/investments.component.ts
@@ -22,7 +22,6 @@ import { DataDictionary } from '@api/models/data-dictionary.model';
 })
 export class InvestmentsComponent implements OnInit {
 
-  public defExpanded: boolean = false;
   public tableCols: Column[] = [];
   public selectedTab: string = 'All';
   public filterTotals: any = null;
@@ -54,10 +53,6 @@ export class InvestmentsComponent implements OnInit {
     private router: Router
   ) {
     // this.modalService.currentInvest.subscribe((row) => (this.row = row));
-  }
-
-  public onViewAll(): void {
-    this.defExpanded = !this.defExpanded;
   }
 
   public onSelectTab(tabName: string): void {

--- a/src/app/views/systems/websites/websites.component.html
+++ b/src/app/views/systems/websites/websites.component.html
@@ -13,7 +13,7 @@
   </div>
   <div class="websites-definition-container">
     <p class="websites-definition-text">
-      This report lists GSA’s public-facing websites that are available to anyone online without a login or firewall. It helps teams understand how the public accesses and interacts with GSA services and information. The data comes from the Touchpoints website inventory and Enterprise Digital Experience (EDX) website scans.
+      This report lists GSA’s public-facing websites that are available to anyone online without a login or firewall. It helps teams understand how the public accesses and interacts with GSA services and information. The data comes from the <a href='https://touchpoints.app.cloud.gov/admin/websites' target='_blank' rel='noopener'>Touchpoints</a> website inventory and website scans.
     </p>
     </div>
     <div class="websites-data-container">

--- a/src/app/views/systems/websites/websites.component.html
+++ b/src/app/views/systems/websites/websites.component.html
@@ -12,10 +12,9 @@
     </div>
   </div>
   <div class="websites-definition-container">
-    <p #definitionText class="websites-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+    <p class="websites-definition-text">
       This report lists GSA’s public-facing websites that are available to anyone online without a login or firewall. It helps teams understand how the public accesses and interacts with GSA services and information. The data comes from the Touchpoints website inventory and Enterprise Digital Experience (EDX) website scans.
     </p>
-      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
     </div>
     <div class="websites-data-container">
       <app-table visibleColumnStorageKey="websites-report" defaultSortField="domain" [tableCols]="tableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" (rowClickEvent)="onRowClick($event)">

--- a/src/app/views/systems/websites/websites.component.html
+++ b/src/app/views/systems/websites/websites.component.html
@@ -12,13 +12,10 @@
     </div>
   </div>
   <div class="websites-definition-container">
-    <p class="websites-definition-text" [ngClass]="{'expanded' : defExpanded}">This report represents GSA's inventory of public-facing websites (i.e. accessible to the general public
-      and not behind any authentication or firewall). This report can be used to better understand how the public views and interacts with GSA's
-      business services, offerings, and information. This data is imported from the
-      <a href='https://touchpoints.app.cloud.gov/admin/websites' target='_blank' rel='noopener'>Touchpoints websites inventory</a>
-      as well as from the Enterprise Digital Experience (EDX) team's
-      <a href='https://github.com/GSA/EDX/tree/main/Tools/edxcli' target='_blank' rel='noopener'>ecxcli website scans</a>.</p>
-      <app-button [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
+    <p #definitionText class="websites-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+      This report lists GSA’s public-facing websites that are available to anyone online without a login or firewall. It helps teams understand how the public accesses and interacts with GSA services and information. The data comes from the Touchpoints website inventory and Enterprise Digital Experience (EDX) website scans.
+    </p>
+      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
     </div>
     <div class="websites-data-container">
       <app-table visibleColumnStorageKey="websites-report" defaultSortField="domain" [tableCols]="tableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" (rowClickEvent)="onRowClick($event)">

--- a/src/app/views/systems/websites/websites.component.scss
+++ b/src/app/views/systems/websites/websites.component.scss
@@ -29,6 +29,17 @@
         & .websites-definition-text {
             margin-bottom: .5rem;
 
+            a {
+                color: #005ea2;
+                text-decoration: underline;
+
+                &:hover,
+                &:focus {
+                    color: #1a4480;
+                    text-decoration-thickness: 2px;
+                }
+            }
+
             &.truncated {
                 display: -webkit-box;
                 -webkit-line-clamp: 4;

--- a/src/app/views/systems/websites/websites.component.scss
+++ b/src/app/views/systems/websites/websites.component.scss
@@ -27,11 +27,14 @@
          border-radius: 0.3rem;
 
         & .websites-definition-text {
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;  
-            overflow: hidden;
             margin-bottom: .5rem;
+
+            &.truncated {
+                display: -webkit-box;
+                -webkit-line-clamp: 4;
+                -webkit-box-orient: vertical;  
+                overflow: hidden;
+            }
 
             &.expanded {
                 -webkit-line-clamp: none;

--- a/src/app/views/systems/websites/websites.component.ts
+++ b/src/app/views/systems/websites/websites.component.ts
@@ -286,9 +286,8 @@ export class WebsitesComponent implements OnInit, AfterViewInit {
       return false;
     }
 
-    const words = text.trim().split(/\s+/).length;
-    const wordThreshold = 40;
-    return words > wordThreshold || isOverflow;
+    // Only show view-more when the rendered text is actually truncated
+    return isOverflow;
   }
 
   public onSelectTab(tabName: string): void {

--- a/src/app/views/systems/websites/websites.component.ts
+++ b/src/app/views/systems/websites/websites.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -18,10 +18,7 @@ import { DataDictionary } from '@api/models/data-dictionary.model';
     styleUrls: ['./websites.component.scss'],
     standalone: false
 })
-export class WebsitesComponent implements OnInit, AfterViewInit {
-  @ViewChild('definitionText') public definitionText: ElementRef;
-  public defExpanded: boolean = false;
-  public showViewMore: boolean = false;
+export class WebsitesComponent implements OnInit {
   public selectedTab: string = 'All';
   public filterTotals: any = null;
   public websitesData: Website[] = [];
@@ -36,8 +33,7 @@ export class WebsitesComponent implements OnInit, AfterViewInit {
     private router: Router,
     public sharedService: SharedService,
     private tableService: TableService,
-    private titleService: Title,
-    private cdRef: ChangeDetectorRef
+    private titleService: Title
   ) {}
 
   // filterButtons: TwoDimArray<FilterButton> = [
@@ -259,36 +255,6 @@ export class WebsitesComponent implements OnInit, AfterViewInit {
   //   this.tableData = this.filteredTableData;
   //   this.tableService.updateReportTableData(this.tableData);
   // }
-
-  public onViewAll(): void {
-    this.defExpanded = !this.defExpanded;
-  }
-
-  public ngAfterViewInit(): void {
-    setTimeout(() => {
-      this.updateViewMoreVisibility();
-      this.cdRef.detectChanges();
-    });
-  }
-
-  private updateViewMoreVisibility(): void {
-    if (!this.definitionText || !this.definitionText.nativeElement) {
-      this.showViewMore = false;
-      return;
-    }
-
-    const el = this.definitionText.nativeElement as HTMLElement;
-    this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
-  }
-
-  private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
-    if (!text || !text.trim()) {
-      return false;
-    }
-
-    // Only show view-more when the rendered text is actually truncated
-    return isOverflow;
-  }
 
   public onSelectTab(tabName: string): void {
     this.selectedTab = tabName;

--- a/src/app/views/systems/websites/websites.component.ts
+++ b/src/app/views/systems/websites/websites.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -18,8 +18,10 @@ import { DataDictionary } from '@api/models/data-dictionary.model';
     styleUrls: ['./websites.component.scss'],
     standalone: false
 })
-export class WebsitesComponent implements OnInit {
+export class WebsitesComponent implements OnInit, AfterViewInit {
+  @ViewChild('definitionText') public definitionText: ElementRef;
   public defExpanded: boolean = false;
+  public showViewMore: boolean = false;
   public selectedTab: string = 'All';
   public filterTotals: any = null;
   public websitesData: Website[] = [];
@@ -34,7 +36,8 @@ export class WebsitesComponent implements OnInit {
     private router: Router,
     public sharedService: SharedService,
     private tableService: TableService,
-    private titleService: Title
+    private titleService: Title,
+    private cdRef: ChangeDetectorRef
   ) {}
 
   // filterButtons: TwoDimArray<FilterButton> = [
@@ -259,6 +262,33 @@ export class WebsitesComponent implements OnInit {
 
   public onViewAll(): void {
     this.defExpanded = !this.defExpanded;
+  }
+
+  public ngAfterViewInit(): void {
+    setTimeout(() => {
+      this.updateViewMoreVisibility();
+      this.cdRef.detectChanges();
+    });
+  }
+
+  private updateViewMoreVisibility(): void {
+    if (!this.definitionText || !this.definitionText.nativeElement) {
+      this.showViewMore = false;
+      return;
+    }
+
+    const el = this.definitionText.nativeElement as HTMLElement;
+    this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
+  }
+
+  private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
+    if (!text || !text.trim()) {
+      return false;
+    }
+
+    const words = text.trim().split(/\s+/).length;
+    const wordThreshold = 40;
+    return words > wordThreshold || isOverflow;
   }
 
   public onSelectTab(tabName: string): void {

--- a/src/app/views/technologies/it-standards/it-standards.component.html
+++ b/src/app/views/technologies/it-standards/it-standards.component.html
@@ -15,10 +15,9 @@
     </div>
   </div>
   <div class="it-standards-definition-container">
-    <p #definitionText class="it-standards-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+    <p class="it-standards-definition-text">
       The IT Standards Inventory is GSA’s repository for approved software. It ensures users access only IT Security-authorized products. For more details, visit the <a href='https://sites.google.com/a/gsa.gov/it_standards/it-standards' target='_blank' rel='noopener'>IT Standards site</a>.
     </p>
-      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
     </div>
     <div class="it-standards-data-container">
       <app-filter-chips [chips]="filterChips" dropdownName="Deployment Types" (chipSelect)="onFilterChipSelect($event)"></app-filter-chips>

--- a/src/app/views/technologies/it-standards/it-standards.component.html
+++ b/src/app/views/technologies/it-standards/it-standards.component.html
@@ -15,13 +15,10 @@
     </div>
   </div>
   <div class="it-standards-definition-container">
-    <p class="it-standards-definition-text" [ngClass]="{'expanded' : defExpanded}">The IT Standards inventory is the official GSA repository of software products/versions.
-      This inventory can be used to determine which software has been reviewed and approved, ensuring that users are only requesting
-      and using software that has been approved by IT Security. The Chief Technology Office (CTO) is responsible for managing
-      the process and ensuring IT Standards are reviewed for use within GSA.
-      For more information, please see the
-      <a href='https://sites.google.com/a/gsa.gov/it_standards/it-standards' target='_blank' rel='noopener'>IT Standards site</a></p>
-      <app-button [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
+    <p #definitionText class="it-standards-definition-text" [ngClass]="{'expanded' : defExpanded, 'truncated': showViewMore && !defExpanded}">
+      The IT Standards Inventory is GSA’s repository for approved software. It ensures users access only IT Security-authorized products. For more details, visit the <a href='https://sites.google.com/a/gsa.gov/it_standards/it-standards' target='_blank' rel='noopener'>IT Standards site</a>.
+    </p>
+      <app-button *ngIf="showViewMore" [buttonText]="defExpanded ? 'View Less' : 'View More'" buttonStyle="link" (buttonClick)="onViewAll()"></app-button>
     </div>
     <div class="it-standards-data-container">
       <app-filter-chips [chips]="filterChips" dropdownName="Deployment Types" (chipSelect)="onFilterChipSelect($event)"></app-filter-chips>

--- a/src/app/views/technologies/it-standards/it-standards.component.scss
+++ b/src/app/views/technologies/it-standards/it-standards.component.scss
@@ -26,11 +26,14 @@
         border-radius: 0.3rem;
 
         & .it-standards-definition-text {
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
             margin-bottom: 5px;
+
+            &.truncated {
+                display: -webkit-box;
+                -webkit-line-clamp: 4;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+            }
 
             &.expanded {
                 -webkit-line-clamp: none;

--- a/src/app/views/technologies/it-standards/it-standards.component.scss
+++ b/src/app/views/technologies/it-standards/it-standards.component.scss
@@ -28,6 +28,17 @@
         & .it-standards-definition-text {
             margin-bottom: 5px;
 
+            a {
+                color: #005ea2;
+                text-decoration: underline;
+
+                &:hover,
+                &:focus {
+                    color: #1a4480;
+                    text-decoration-thickness: 2px;
+                }
+            }
+
             &.truncated {
                 display: -webkit-box;
                 -webkit-line-clamp: 4;

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
@@ -20,7 +20,11 @@ import { Column } from '@common/table-classes';
     styleUrls: ['./it-standards.component.scss'],
     standalone: false
 })
-export class ItStandardsComponent implements OnInit {
+export class ItStandardsComponent implements OnInit, AfterViewInit {
+  @ViewChild('definitionText') public definitionText!: ElementRef;
+  public showViewMore: boolean = false;
+  public defExpanded: boolean = false;
+
   // row: Object = <any>{};
   // filteredTable: boolean = false;
   // filterTitle: string = '';
@@ -28,7 +32,6 @@ export class ItStandardsComponent implements OnInit {
   // columnDefs: any[] = [];
   // dataReady: boolean = false;
 
-  public defExpanded: boolean = false;
   public tableCols: Column[] = [];
   public selectedTab: string = 'All';
   public filterTotals: any = null;
@@ -50,7 +53,8 @@ export class ItStandardsComponent implements OnInit {
     public sharedService: SharedService,
     private tableService: TableService,
     private titleService: Title,
-    private router: Router
+    private router: Router,
+    private cdRef: ChangeDetectorRef
   ) {
     // this.modalService.currentITStand.subscribe((row) => (this.row = row));
   }
@@ -65,6 +69,33 @@ export class ItStandardsComponent implements OnInit {
 
   public onViewAll(): void {
     this.defExpanded = !this.defExpanded;
+  }
+
+  public ngAfterViewInit(): void {
+    setTimeout(() => {
+      this.updateViewMoreVisibility();
+      this.cdRef.detectChanges();
+    });
+  }
+
+  private updateViewMoreVisibility(): void {
+    if (!this.definitionText || !this.definitionText.nativeElement) {
+      this.showViewMore = false;
+      return;
+    }
+
+    const el = this.definitionText.nativeElement as HTMLElement;
+    this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
+  }
+
+  private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
+    if (!text || !text.trim()) {
+      return false;
+    }
+
+    const words = text.trim().split(/\s+/).length;
+    const wordThreshold = 40;
+    return words > wordThreshold || isOverflow;
   }
 
   public onSelectTab(tabName: string): void {
@@ -137,7 +168,7 @@ export class ItStandardsComponent implements OnInit {
     return this.selectedChips && this.selectedChips.length > 0;
   }
 
-  private YesNo(value, row, index, field): string {
+  private YesNo(value: any, row: any, index: number, field: string): string {
     return value === 'T'? "Yes" : "No";
   }
 
@@ -384,7 +415,7 @@ export class ItStandardsComponent implements OnInit {
         const expiringWithin = new Date();
         expiringWithin.setDate(now.getDate() + this.daysExpiring); // number of days set in the url
         expiringWithin.setUTCHours(0, 0, 0, 0);
-        const expiringFiltered = [];
+        const expiringFiltered: ITStandards[] = [];
         i.forEach(x => {
           let renewal = new Date(x.ApprovalExpirationDate);
           renewal.setUTCHours(0, 0, 0, 0);
@@ -400,7 +431,7 @@ export class ItStandardsComponent implements OnInit {
         const expiredWithin = new Date();
         expiredWithin.setDate(now.getDate() - this.daysRetired); // number of days set in the url
         expiredWithin.setUTCHours(0, 0, 0, 0);
-        const expiringFiltered = [];
+        const expiringFiltered: ITStandards[] = [];
         i.forEach(x => {
           let renewal = new Date(x.ApprovalExpirationDate);
           renewal.setUTCHours(0, 0, 0, 0);

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
@@ -20,10 +20,7 @@ import { Column } from '@common/table-classes';
     styleUrls: ['./it-standards.component.scss'],
     standalone: false
 })
-export class ItStandardsComponent implements OnInit, AfterViewInit {
-  @ViewChild('definitionText') public definitionText!: ElementRef;
-  public showViewMore: boolean = false;
-  public defExpanded: boolean = false;
+export class ItStandardsComponent implements OnInit {
 
   // row: Object = <any>{};
   // filteredTable: boolean = false;
@@ -53,8 +50,7 @@ export class ItStandardsComponent implements OnInit, AfterViewInit {
     public sharedService: SharedService,
     private tableService: TableService,
     private titleService: Title,
-    private router: Router,
-    private cdRef: ChangeDetectorRef
+    private router: Router
   ) {
     // this.modalService.currentITStand.subscribe((row) => (this.row = row));
   }
@@ -65,36 +61,6 @@ export class ItStandardsComponent implements OnInit, AfterViewInit {
 
   public onCreateNew(): void {
     this.router.navigate(['/it_standards_manager']);
-  }
-
-  public onViewAll(): void {
-    this.defExpanded = !this.defExpanded;
-  }
-
-  public ngAfterViewInit(): void {
-    setTimeout(() => {
-      this.updateViewMoreVisibility();
-      this.cdRef.detectChanges();
-    });
-  }
-
-  private updateViewMoreVisibility(): void {
-    if (!this.definitionText || !this.definitionText.nativeElement) {
-      this.showViewMore = false;
-      return;
-    }
-
-    const el = this.definitionText.nativeElement as HTMLElement;
-    this.showViewMore = this.shouldShowViewMore(el.innerText, el.scrollHeight > el.clientHeight + 1);
-  }
-
-  private shouldShowViewMore(text: string, isOverflow: boolean): boolean {
-    if (!text || !text.trim()) {
-      return false;
-    }
-
-    // Only show view-more when the rendered text is actually truncated
-    return isOverflow;
   }
 
   public onSelectTab(tabName: string): void {

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -93,9 +93,8 @@ export class ItStandardsComponent implements OnInit, AfterViewInit {
       return false;
     }
 
-    const words = text.trim().split(/\s+/).length;
-    const wordThreshold = 40;
-    return words > wordThreshold || isOverflow;
+    // Only show view-more when the rendered text is actually truncated
+    return isOverflow;
   }
 
   public onSelectTab(tabName: string): void {


### PR DESCRIPTION
Cleaned up the IT Standards component by removing the duplicate defExpanded property and fixing related TypeScript issues (ViewChild null safety, type annotations, and temporary array typing). After that, Implemented the updated View More / View Less behavior across all components by removing the word-count logic and relying only on actual text overflow, ensuring the toggle appears only when content is truly truncated.

Issue:
https://github.com/GSA/GEAR3/issues/977
https://github.com/GSA/GEAR3/issues/976
https://github.com/GSA/GEAR3/issues/975
https://github.com/GSA/GEAR3/issues/974
https://github.com/GSA/GEAR3/issues/972
https://github.com/GSA/GEAR3/issues/945

Root Cause:
Duplicate property declaration in IT Standards (defExpanded) caused TypeScript conflicts.
Missing or weak type definitions led to strict-type errors (e.g., ViewChild, YesNo, temporary arrays).
Incorrect toggle logic relied on word count, which doesn’t accurately reflect UI truncation.

Fix:
Removed duplicate defExpanded declaration.
Added proper type annotations and fixed null-safety issues.
Simplified toggle logic to rely only on actual overflow (isOverflow).