### PR TITLE
Added a frontend API method to load subsystems from the existing

### DIFF
--- a/api/controllers/systems.controller.js
+++ b/api/controllers/systems.controller.js
@@ -27,14 +27,21 @@ exports.findOne = (req, res) => {
 };
 
 exports.findSubsystems = (req, res) => {
-  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_systems.sql')).toString() +
-    ` WHERE systems.\`ex:FISMA_System_Identifier\` = 
-        (SELECT systems.\`ex:FISMA_System_Identifier\`
-        FROM obj_fisma_archer AS systems
-        WHERE systems.\`ex:GEAR_ID\` = ${req.params.id} )
-      AND systems.\`ex:SystemLevel\` = 'SubSystem';`;
-      
-  res = ctrl.sendQuery(query, 'Subsystems', res);
+  let id = req.params.id.trim();
+  if(/^[0-9]+$/.test(id)) {
+    var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_systems.sql')).toString() +
+      ` WHERE systems.\`ex:Parent_Name\` =
+          (SELECT parent_system.\`ex:System_Name\`
+           FROM obj_fisma_archer AS parent_system
+           WHERE parent_system.\`ex:GEAR_ID\` = ${id})
+        AND LOWER(systems.\`ex:SystemLevel\`) = 'subsystem';`;
+
+    res = ctrl.sendQuery(query, 'Subsystems', res);
+  } else {
+    res.status(404).json({
+      message: 'ID not found',
+    });
+  }
 };
 
 exports.findCapabilities = (req, res) => {

--- a/src/app/services/apis/api.service.ts
+++ b/src/app/services/apis/api.service.ts
@@ -502,6 +502,18 @@ export class ApiService {
         )
       );
   }
+  public getSysSubsystems(id: number): Observable<System[]> {
+    return this.http
+      .get<System[]>(this.sysUrl + '/get/' + String(id) + '/subsystems')
+      .pipe(
+        catchError(
+          this.handleError<System[]>(
+            'GET System Related Subsystems',
+            []
+          )
+        )
+      );
+  }
   public getSystemsFilterTotals(): Observable<any> {
     return this.http
     .get<any>(this.sysUrl + '/filter_totals')

--- a/src/app/views/systems/systems/details/systems-details.component.html
+++ b/src/app/views/systems/systems/details/systems-details.component.html
@@ -22,6 +22,11 @@
         <li class="nav-item">
           <a class="nav-link" [class.active]="isRecordsTabActive" (click)="onTabClick('records', $event)" href="#records">Records</a>
         </li>
+        @if(showSubsystemsTab()){
+          <li class="nav-item">
+            <a class="nav-link" [class.active]="isSubsystemsTabActive" (click)="onTabClick('subsystems', $event)" href="#subsystems">Subsystems</a>
+          </li>
+        }
         @if(sysWebsitesData && sysWebsitesData.length > 0){
           <li class="nav-item">
             <a class="nav-link" [class.active]="isWebsitesTabActive" (click)="onTabClick('websites', $event)" href="#websites">Websites</a>
@@ -350,6 +355,18 @@
               <div class="sub-content full-width">
                 <span class="sub-header">Related Websites</span>
                 <app-table visibleColumnStorageKey="systems-related-websites" defaultSortField="domain" [localTableData]="sysWebsitesData" [isLocal]="true" [tableCols]="websiteCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="website" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onRelatedWebsitesRowClick($event)"></app-table>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+      @if (isSubsystemsTabActive) {
+        <div class="tab-container">
+          <div class="overall-data-container">
+            <div class="main-data-container">
+              <div class="sub-content full-width">
+                <span class="sub-header">Related Subsystems</span>
+                <app-table visibleColumnStorageKey="systems-related-subsystems" defaultSortField="Name" [localTableData]="sysSubsystemsData" [isLocal]="true" [tableCols]="relatedSystemsCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="systems" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onRelatedSubsystemsRowClick($event)"></app-table>
               </div>
             </div>
           </div>

--- a/src/app/views/systems/systems/details/systems-details.component.ts
+++ b/src/app/views/systems/systems/details/systems-details.component.ts
@@ -12,6 +12,7 @@ import { PreviousRouteService } from '@services/previous-route/previous-route.se
 import { RelatedTechnologiesColumns } from '@common/table-columns/related-technologies';
 import { RecordsColumns } from '@common/table-columns/records';
 import { WebsitesColumns } from '@common/table-columns/websites';
+import { RelatedSystemsCols } from '@common/table-columns/related-systems';
 import { Capability } from '@api/models/capabilities.model';
 import { ITStandards } from '@api/models/it-standards.model';
 import { Record } from '@api/models/records.model';
@@ -40,18 +41,21 @@ export class SystemsDetailsComponent implements OnInit {
   public sysTechnologiesData: ITStandards[] = [];
   public sysRecordsData: Record[] = [];
   public sysWebsitesData: Website[] = [];
+  public sysSubsystemsData: System[] = [];
 
   public isOverviewTabActive: boolean = true;
   public isBusinessTabActive: boolean = false;
   public isTechnicalTabActive: boolean = false;
   public isRecordsTabActive: boolean = false;
   public isWebsitesTabActive: boolean = false;
+  public isSubsystemsTabActive: boolean = false;
 
   public systemTimeCols: Column[] = SystemTimeColumns;
   public relatedCapabilitiesCols: Column[] = RelatedCapabilitiesColumns;
   public relatedTechnologyCols: Column[] = RelatedTechnologiesColumns;
   public recordsCols: Column[] = RecordsColumns;
   public websiteCols: Column[] = WebsitesColumns;
+  public relatedSystemsCols: Column[] = RelatedSystemsCols;
 
   public attrDefinitions = <DataDictionary[]>[];
 
@@ -79,6 +83,7 @@ export class SystemsDetailsComponent implements OnInit {
         this.apiService.getSysITStandards(this.systemId),
         this.apiService.getSysRecords(this.systemId),
         this.apiService.getSysWebsites(this.systemId),
+        this.apiService.getSysSubsystems(this.systemId),
         this.apiService.getRecords(),
         this.apiService.getWebsites()
       ]).subscribe({
@@ -90,6 +95,7 @@ export class SystemsDetailsComponent implements OnInit {
           systemITStandards,
           systemRecords,
           systemWebsites,
+          systemSubsystems,
           records,
           websites
         ]) => {
@@ -105,6 +111,8 @@ export class SystemsDetailsComponent implements OnInit {
 
           const websiteIds = new Set(systemWebsites.map(({ obj_websites_Id }) => obj_websites_Id));
           this.sysWebsitesData = websites.filter(({ website_id }) => websiteIds.has(parseInt(website_id)));
+
+          this.sysSubsystemsData = systemSubsystems;
 
           this.splitPOCs = this.splitPOCInfo(this.detailsData.POC);
         },
@@ -172,6 +180,7 @@ export class SystemsDetailsComponent implements OnInit {
         this.isTechnicalTabActive = false;
         this.isRecordsTabActive = false;
         this.isWebsitesTabActive = false;
+        this.isSubsystemsTabActive = false;
         break;
       case 'business':
         this.isOverviewTabActive = false;
@@ -179,6 +188,7 @@ export class SystemsDetailsComponent implements OnInit {
         this.isTechnicalTabActive = false;
         this.isRecordsTabActive = false;
         this.isWebsitesTabActive = false;
+        this.isSubsystemsTabActive = false;
         break;
       case 'technical':
         this.isOverviewTabActive = false;
@@ -186,6 +196,7 @@ export class SystemsDetailsComponent implements OnInit {
         this.isTechnicalTabActive = true;
         this.isRecordsTabActive = false;
         this.isWebsitesTabActive = false;
+        this.isSubsystemsTabActive = false;
         break;
       case 'records':
         this.isOverviewTabActive = false;
@@ -193,6 +204,7 @@ export class SystemsDetailsComponent implements OnInit {
         this.isTechnicalTabActive = false;
         this.isRecordsTabActive = true;
         this.isWebsitesTabActive = false;
+        this.isSubsystemsTabActive = false;
         break;
       case 'websites':
         this.isOverviewTabActive = false;
@@ -200,6 +212,15 @@ export class SystemsDetailsComponent implements OnInit {
         this.isTechnicalTabActive = false;
         this.isRecordsTabActive = false;
         this.isWebsitesTabActive = true;
+        this.isSubsystemsTabActive = false;
+        break;
+      case 'subsystems':
+        this.isOverviewTabActive = false;
+        this.isBusinessTabActive = false;
+        this.isTechnicalTabActive = false;
+        this.isRecordsTabActive = false;
+        this.isWebsitesTabActive = false;
+        this.isSubsystemsTabActive = true;
         break;
       default:
         break;
@@ -304,5 +325,15 @@ export class SystemsDetailsComponent implements OnInit {
     this.router.navigate(['/websites', data.website_id], {
       queryParams: { fromPrevious: this.detailsData.Name }
     });
+  }
+
+  public onRelatedSubsystemsRowClick(data: System): void {
+    this.router.navigate(['/systems', data.ID], {
+      queryParams: { fromPrevious: this.detailsData.Name }
+    });
+  }
+
+  public showSubsystemsTab(): boolean {
+    return this.detailsData?.SystemLevel?.trim()?.toLowerCase() === 'system';
   }
 }

--- a/src/app/views/systems/systems/systems.component.html
+++ b/src/app/views/systems/systems/systems.component.html
@@ -47,3 +47,5 @@
         </div>
       </app-table>
     </div>
+
+    <systems-modal></systems-modal>

--- a/src/app/views/systems/systems/systems.component.ts
+++ b/src/app/views/systems/systems/systems.component.ts
@@ -487,10 +487,7 @@ export class SystemsComponent implements OnInit {
   }
 
   public onRowClick(e: any) {
-    const searchTerm: string = e.tableSearchString || '';
-    this.router.navigate(['/systems', e.ID], {
-        queryParams: { tableSearchTerm: searchTerm }
-    });
+    this.tableService.systemsTableClick(e);
   }
 
   onSelect(chartData: any): void {


### PR DESCRIPTION
endpoint.

Ticket:
https://github.com/GSA/GEAR3/issues/1004

Issue:
Subsystems were not consistently shown/loaded in the Business Systems detail experience for System-level records.
In backend logic, subsystem lookup could return incorrect children because it matched by FISMA identifier instead of parent linkage. In the newer details UI route, there was no subsystem fetch/tab wiring at all.

Rootcause:
Backend query mismatch:
In systems.controller.js, subsystem lookup was previously based on ex:FISMA_System_Identifier, but your data model defines parent-child through ex:Parent_Name.
Frontend gap:
The details page under /systems/:id did not call the subsystems API and had no Subsystems tab state/rendering in systems-details.component.ts and systems-details.component.html

Fix:
Backend:
Updated subsystem endpoint to join by parent name linkage:
Child systems where systems.ex:Parent_Name = parent ex:System_Name for the selected GEAR_ID.
Added numeric ID validation in that handler.
See systems.controller.js.
Frontend API:
Added dedicated subsystem fetch method:
api.service.ts.
Frontend details page:
Added subsystem dataset, tab state, click handling, and conditional visibility only when SystemLevel is system (case-insensitive/trimmed):
systems-details.component.ts
systems-details.component.html
