### PR TITLE
fix: Updated all More Help report to replace CTA wording from “lick t…

### DIFF
--- a/src/app/components/page-help-button/page-help-button.component.html
+++ b/src/app/components/page-help-button/page-help-button.component.html
@@ -1,14 +1,14 @@
 <app-button-overlay-panel buttonText="More Help" buttonIcon="far fa-question-circle" buttonIconPos="right">
   <span>
-    <b>Details:</b> Left click on a row within the table to view additional details.
+    <b>Details:</b> Select a row within the table to view additional details.
     <br><br>
-    <b>Sorting:</b> Sort fields by clicking on the arrows in the column headers.
+    <b>Sorting:</b> Sort fields by selecting the arrows in the column headers.
     <br><br>
-    <b>Add/Remove Columns:</b> Click the <i class="fas fa-th-list"></i> to add or remove available data fields.
+    <b>Add/Remove Columns:</b> Select the <i class="fas fa-th-list"></i> to add or remove available data fields.
     <br><br>
-    <b>Filtering:</b> Click the <i class="fas fa-filter"></i> icon to open the filter window.
+    <b>Filtering:</b> Select the <i class="fas fa-filter"></i> icon to open the filter window.
     <br><br>
-    <b>Export:</b> Export data by clicking on the <i class='fas fa-download'></i> icon.
+    <b>Export:</b> Export data by selecting the <i class='fas fa-download'></i> icon.
     <br><br>
     <b>Search:</b> Perform a filtered search across all fields in the data table.
     <br><br>

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.html
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.html
@@ -4,15 +4,15 @@
     <div class="capabilities-title-right-button-container">
       <app-button-overlay-panel buttonText="More Help" buttonIcon="far fa-question-circle" buttonIconPos="right">
         <b>Hover:</b> Hover over a circle next to a capabilities to see its description.
-        In the pop-up window, click the <i class='far fa-file-alt'></i> icon to see additional information about the capabilities
-        or click the <i class='fa fa-times'></i> icon to close the window.
+        In the pop-up window, select the <i class='far fa-file-alt'></i> icon to see additional information about the capabilities
+        or select the <i class='fa fa-times'></i> icon to close the window.
         <br><br>
-        <b>Click:</b> Left click on the circle next to a capabilities to see the next level of the capabilities.
+        <b>Select:</b> Select the circle next to a capabilities to see the next level of the capabilities.
         (Not all capabilities have another level).
         <br><br>
         <b>Search:</b> The search box below can search for any of the capabilities display names and expand the chart to the nodes that match.
         Enter your desired term into the search bar and press <i>Enter</i>. You will get an alert if no matching term is found.
-        Click the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart. Click on the
+        Select the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart. Select the
         <i class='fas fa-caret-square-down'></i> icon to display everything on one page.
       </app-button-overlay-panel>
     </div>
@@ -29,7 +29,7 @@
         <h4 id="capName" class="text-white custom-hover-cursor"></h4>
         <div class="ml-auto">
           <span id="capDetailLink" class="far fa-file-alt fa-lg" data-bs-toggle="tooltip"
-            title="Click to view capability details"></span>
+            title="Select to view capability details"></span>
           <span id="capDetailClose" class="fa fa-times fa-lg ml-3" data-bs-toggle="tooltip" title="Close this box"></span>
         </div>
       </div>
@@ -69,15 +69,15 @@
     class="btn btn-sm btn-info text-white shadow help-btn d-flex align-items-center justify-content-center"
       role="button" data-bs-toggle="popover" data-bs-trigger="focus" data-bs-placement="auto" data-bs-html="true"
       title="Help Using this Table" data-bs-content="<b>Hover:</b> Hover over a circle next to an capabilities to see its description.
-        In the pop-up window, click the <i class='far fa-file-alt'></i> icon to see additional information about the capabilities
-        or click the <i class='fa fa-times'></i> icon to close the window.
+        In the pop-up window, select the <i class='far fa-file-alt'></i> icon to see additional information about the capabilities
+        or select the <i class='fa fa-times'></i> icon to close the window.
         <br><br>
-        <b>Click:</b> Left click on the circle next to an capabilities to see the next level of the capabilities.
+        <b>Select:</b> Select the circle next to an capabilities to see the next level of the capabilities.
         (Not all capabilities have another level).
         <br><br>
         <b>Search:</b> The search box below can search for any of the capabilities display names and expand the chart to the nodes that match.
         Enter your desired term into the search bar and press <i>Enter</i>. You will get an alert if no matching term is found.
-        Click the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart.">
+        Select the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart.">
       <span class="mr-2">More Help</span><i class="far fa-question-circle fa-2x"></i>
     </a>
   </div>
@@ -104,7 +104,7 @@
         <h4 id="capName" class="text-white custom-hover-cursor"></h4>
         <div class="ml-auto">
           <span id="capDetailLink" class="far fa-file-alt fa-lg" data-bs-toggle="tooltip"
-            title="Click to view capability details"></span>
+            title="Select to view capability details"></span>
           <span id="capDetailClose" class="fa fa-times fa-lg ml-3" data-bs-toggle="tooltip" title="Close this box"></span>
         </div>
       </div>

--- a/src/app/views/enterprise/organizations-chart/organizations-chart.component.html
+++ b/src/app/views/enterprise/organizations-chart/organizations-chart.component.html
@@ -4,15 +4,15 @@
     <div class="org-title-right-button-container">
       <app-button-overlay-panel buttonText="More Help" buttonIcon="far fa-question-circle" buttonIconPos="right">
         <b>Hover:</b> Hover over a circle next to an organization to see its description. 
-          In the pop-up window, click the <i class='far fa-file-alt'></i> icon to see additional information about the organization 
-          or click the <i class='fa fa-times'></i> icon to close the window.
+          In the pop-up window, select the <i class='far fa-file-alt'></i> icon to see additional information about the organization 
+          or select the <i class='fa fa-times'></i> icon to close the window.
           <br><br>
-          <b>Click:</b> Left click on the circle next to an organization to see the next level of the organizations. 
+          <b>Select:</b> Select the circle next to an organization to see the next level of the organizations. 
           (Not all organizations have another level).
           <br><br>
           <b>Search:</b> The search box below can search for any of the organization display names and expand the chart to the nodes that match. 
           Enter your desired term into the search bar and press <i>Enter</i>. You will get an alert if no matching term is found.
-          Click the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart.
+          Select the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart.
       </app-button-overlay-panel>
     </div>
   </div>
@@ -23,7 +23,7 @@
         <h5 id="orgName" class="text-white"></h5>
         <div class="ml-auto">
           <span id="orgDetailLink" class="far fa-file-alt fa-lg mx-4" data-bs-toggle="tooltip"
-            title="Click to view organization details"></span>
+            title="Select to view organization details"></span>
           <span id="orgDetailClose" class="fa fa-times fa-lg" data-bs-toggle="tooltip" title="Close this box"></span>
         </div>
       </div>
@@ -60,15 +60,15 @@
     <!-- Help Button -->
     <!-- <app-button-overlay-panel buttonText="More Help" buttonIcon="far fa-question-circle" buttonIconPos="right">
       <b>Hover:</b> Hover over a circle next to an organization to see its description. 
-        In the pop-up window, click the <i class='far fa-file-alt'></i> icon to see additional information about the organization 
-        or click the <i class='fa fa-times'></i> icon to close the window.
+        In the pop-up window, select the <i class='far fa-file-alt'></i> icon to see additional information about the organization 
+        or select the <i class='fa fa-times'></i> icon to close the window.
         <br><br>
-        <b>Click:</b> Left click on the circle next to an organization to see the next level of the organizations. 
+        <b>Select:</b> Select the circle next to an organization to see the next level of the organizations. 
         (Not all organizations have another level).
         <br><br>
         <b>Search:</b> The search box below can search for any of the organization display names and expand the chart to the nodes that match. 
         Enter your desired term into the search bar and press <i>Enter</i>. You will get an alert if no matching term is found.
-        Click the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart.
+        Select the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart.
     </app-button-overlay-panel>
   </div>
 
@@ -80,7 +80,7 @@
         <h5 id="orgName" class="text-white"></h5>
         <div class="ml-auto">
           <span id="orgDetailLink" class="far fa-file-alt fa-lg mx-4" data-bs-toggle="tooltip"
-            title="Click to view organization details"></span>
+            title="Select to view organization details"></span>
           <span id="orgDetailClose" class="fa fa-times fa-lg" data-bs-toggle="tooltip" title="Close this box"></span>
         </div>
       </div>

--- a/src/app/views/technologies/tech-categories-model/tech-categories-model.component.html
+++ b/src/app/views/technologies/tech-categories-model/tech-categories-model.component.html
@@ -4,15 +4,15 @@
     <div class="trm-title-right-button-container">
       <app-button-overlay-panel buttonText="More Help" buttonIcon="far fa-question-circle" buttonIconPos="right">
         <b>Hover:</b> Hover over a circle next to a technology category to see its description.
-        In the pop-up window, click the <i class='far fa-file-alt'></i> icon to see additional information about the technology category
-        or click the <i class='fa fa-times'></i> icon to close the window.
+        In the pop-up window, select the <i class='far fa-file-alt'></i> icon to see additional information about the technology category
+        or select the <i class='fa fa-times'></i> icon to close the window.
         <br><br>
-        <b>Click:</b> Left click on the circle next to a technology category to see the next level of the technology category.
+        <b>Select:</b> Select the circle next to a technology category to see the next level of the technology category.
         (Not all technology categories have another level).
         <br><br>
         <b>Search:</b> The search box below can search for any of the technology category display names and expand the chart to the nodes that match.
         Enter your desired term into the search bar and press <i>Enter</i>. You will get an alert if no matching term is found.
-        Click the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart. Click on the
+        Select the <i class='far fa-trash-alt fa-lg'></i> icon to clear the search box and reset the chart. Select the
         <i class='fas fa-caret-square-down'></i> icon to display everything on one page.
       </app-button-overlay-panel>
     </div>
@@ -35,7 +35,7 @@
         <h4 id="trmName" class="text-white custom-hover-cursor"></h4>
         <div class="ml-auto">
           <span id="trmDetailLink" class="far fa-file-alt fa-lg" data-bs-toggle="tooltip"
-            title="Click to view technology category details"></span>
+            title="Select to view technology category details"></span>
           <span id="trmDetailClose" class="fa fa-times fa-lg ml-3" data-bs-toggle="tooltip" title="Close this box"></span>
         </div>
       </div>


### PR DESCRIPTION
…o select.

Ticket:
https://github.com/GSA/GEAR3/issues/1009

Issue:
“More Help” guidance used “click” CTA wording, which is mouse-specific and less accessible for keyboard/touch users.

Rootcause:
UX copy was written with device-specific interaction language.
A direct word swap can also create awkward phrases like “left select” if not rewritten contextually.

Fix:
Rewrote help and tooltip text to use “select” phrasing in a natural way (for example, “Select the icon…” / “Select a row…”).
Kept functionality unchanged; this is a copy/accessibility improvement only.

Build:
<img width="824" height="250" alt="image" src="https://github.com/user-attachments/assets/c8a4ec99-930b-4219-a0b2-6117552b1e64" />
