### PR TITLE
feat: added scoped anchor styling in fisma report for the link

### DIFF
--- a/src/app/views/security/fisma/fisma.component.scss
+++ b/src/app/views/security/fisma/fisma.component.scss
@@ -26,6 +26,17 @@
             overflow: hidden;
             margin-bottom: 5px;
 
+            a {
+                color: #005ea2;
+                text-decoration: underline;
+
+                &:hover,
+                &:focus {
+                    color: #1a4480;
+                    text-decoration-thickness: 2px;
+                }
+            }
+
             &.expanded {
                 -webkit-line-clamp: none;
                 overflow: visible;


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1014

Root cause:
 the FISMA description link was inheriting the default paragraph/link styling in fisma.component.scss, so it did not stand out as an obvious link.

Fix:
added scoped anchor styling inside .fisma-inventory-definition-text to make links blue, underlined, and slightly darker on hover/focus.

Build:
<img width="821" height="236" alt="image" src="https://github.com/user-attachments/assets/5b950892-cda8-45d9-91e7-f91c6296e1f5" />
