### PR TITLE
fix: Override undici to 7.28.0 and align Node engine to 20.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "webpack-bundle-analyzer": "^4.6.1"
       },
       "engines": {
-        "node": ">=18.14.2"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -1108,16 +1108,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/wrap-ansi": {
@@ -22327,13 +22317,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Next Iteration of the GEAR portal to latest tech stack of 2020",
   "main": "server.js",
   "engines": {
-    "node": ">=18.14.2"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "ng": "ng",
@@ -123,5 +123,8 @@
     "typescript": "^5.9.3",
     "typescript-guid": "1.0.3",
     "webpack-bundle-analyzer": "^4.6.1"
+  },
+  "overrides": {
+    "undici": "^7.28.0"
   }
 }


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1012

Issue:
Undici DoS vulnerability (CVE-2026-12151) flagged from transitive dependencies.

Rootcause:
Different dependency paths resolved vulnerable Undici ranges (notably Angular build tooling and node-gyp path), and no top-level override was enforcing a patched version.

Fix: 
Added a global npm override in package.json:127 to force Undici to ^7.28.0, then refreshed lock resolution so Undici is pinned to 7.28.0 in package-lock.json:22319

Build:
<img width="818" height="226" alt="image" src="https://github.com/user-attachments/assets/21b57574-296c-404a-8d36-5c9fd431c986" />
