### PR TITLE
fix: Updated Systems table row click to navigate to the details route…

### DIFF
--- a/src/app/views/systems/systems/systems.component.html
+++ b/src/app/views/systems/systems/systems.component.html
@@ -47,5 +47,3 @@
         </div>
       </app-table>
     </div>
-
-    <systems-modal></systems-modal>

--- a/src/app/views/systems/systems/systems.component.ts
+++ b/src/app/views/systems/systems/systems.component.ts
@@ -487,7 +487,10 @@ export class SystemsComponent implements OnInit {
   }
 
   public onRowClick(e: any) {
-    this.tableService.systemsTableClick(e);
+    const searchTerm: string = e.tableSearchString || '';
+    this.router.navigate(['/systems', e.ID], {
+      queryParams: { tableSearchTerm: searchTerm }
+    });
   }
 
   onSelect(chartData: any): void {


### PR DESCRIPTION
… in the same tab instead of opening a modal or a new tab.

Ticket:
https://github.com/GSA/GEAR3/issues/1004

Issue:
Business Systems details behavior was inconsistent with expected UX and subsystem logic (modal/new-tab/same-tab flow changed across merges, and subsystem visibility had to match system level).

Rootcause:
Row-click handling on the Systems list was changed multiple times (modal vs route/new-tab), causing unintended navigation behavior.
Subsystem handling depended on correct parent-child mapping and conditional tab visibility by SystemLevel.

Fix:
Standardized row click to open details route in the same tab (/systems/:id).
Ensured Subsystems tab shows only for SystemLevel = System, not SubSystem.
Kept backend subsystem retrieval aligned to parent linkage (Parent_Name) for correct child records.

Build:
<img width="810" height="237" alt="image" src="https://github.com/user-attachments/assets/2c8e1201-0885-4f82-b111-cfc722cd47b6" />
