### PR TITLE
Table Font size Requirement

### DIFF
--- a/src/app/components/table-v2/table-v2.component.scss
+++ b/src/app/components/table-v2/table-v2.component.scss
@@ -7,6 +7,7 @@
 
         & .p-datatable-thead > tr > th {
             padding: .5rem .25rem;
+            font-size: 14px;
 
             & .table-heading {
                 justify-content: space-between;
@@ -98,6 +99,7 @@
             background-color: var(--neutral-white-color);
             border: none;
             padding: .625rem;
+            font-size: 14px;
 
             & .table-heading {
                 text-transform: none;
@@ -118,7 +120,7 @@
             border: none;
             border-bottom: 1px var(--neutral-black-color-light) solid;
             padding: 1rem .625rem;
-            font-size: .75rem;    
+            font-size: 12px;
             width: 14rem;
             }
 
@@ -129,9 +131,9 @@
                     border: none;
                     border-bottom: 1px var(--neutral-black-color-light) solid;
                     padding: .5rem;
-                    font-size: .75rem;
+                    font-size: 12px;
                     padding: 1rem .625rem;
-                    font-size: .75rem;    
+                    font-size: 12px;
                     width: 14rem;
                 }
             }

--- a/src/app/components/table-v2/table-v2.component.scss
+++ b/src/app/components/table-v2/table-v2.component.scss
@@ -1,13 +1,13 @@
 ::ng-deep {
     .p-datatable {
         font-family: Nunito Sans, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", Segoe UI Symbol;
-        font-size: 12px;
+        font-size: 0.75rem;
         font-weight: 200;
         line-height: 21px;
 
         & .p-datatable-thead > tr > th {
             padding: .5rem .25rem;
-            font-size: 14px;
+            font-size: 0.875rem;
 
             & .table-heading {
                 justify-content: space-between;
@@ -99,7 +99,7 @@
             background-color: var(--neutral-white-color);
             border: none;
             padding: .625rem;
-            font-size: 14px;
+            font-size: 0.875rem;
 
             & .table-heading {
                 text-transform: none;
@@ -120,7 +120,7 @@
             border: none;
             border-bottom: 1px var(--neutral-black-color-light) solid;
             padding: 1rem .625rem;
-            font-size: 12px;
+            font-size: .75rem;    
             width: 14rem;
             }
 
@@ -131,9 +131,9 @@
                     border: none;
                     border-bottom: 1px var(--neutral-black-color-light) solid;
                     padding: .5rem;
-                    font-size: 12px;
+                    font-size: .75rem;
                     padding: 1rem .625rem;
-                    font-size: 12px;
+                    font-size: .75rem;    
                     width: 14rem;
                 }
             }
@@ -151,12 +151,12 @@
             color: #fff;
             border-color: #4a5055;
             padding: .5rem 1.5rem;
-            font-size: 12px;
+            font-size: 0.75rem;
 
             & .table-status-badge-green {
                 background: #EEF6EE;
                 color: #006100;
-                font-size: 12px;
+                font-size: 0.75rem;
                 font-style: normal;
                 font-weight: 400;
                 line-height: normal;
@@ -170,7 +170,7 @@
             & .table-status-badge-red {
                 background: #FFEFD6;
                 color: #943600;
-                font-size: 12px;
+                font-size: 0.75rem;
                 font-style: normal;
                 font-weight: 400;
                 line-height: normal;
@@ -188,12 +188,12 @@
             & td {
                 border-color: #343a40;
                 padding: .5rem 1.5rem;
-                font-size: 12px;
+                font-size: 0.75rem;
 
                 & .table-status-badge-green {
                     background: #EEF6EE;
                     color: #006100;
-                    font-size: 12px;
+                    font-size: 0.75rem;
                     font-style: normal;
                     font-weight: 400;
                     line-height: normal;
@@ -207,7 +207,7 @@
                 & .table-status-badge-red {
                     background: #FFEFD6;
                     color: #943600;
-                    font-size: 12px;
+                    font-size: 0.75rem;
                     font-style: normal;
                     font-weight: 400;
                     line-height: normal;

--- a/src/app/components/table/table.component.scss
+++ b/src/app/components/table/table.component.scss
@@ -134,7 +134,7 @@
 
     .p-datatable {
         font-family: Nunito Sans, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", Segoe UI Symbol;
-        font-size: 12px;
+        font-size: 0.75rem;
         font-weight: 200;
         line-height: 21px;
         display: flex;
@@ -151,7 +151,7 @@
 
         & .p-datatable-thead>tr>th {
             padding: .5rem .25rem;
-            font-size: 14px;
+            font-size: 0.875rem;
             // background-color: #ececec;
             background-color: var(--primary-color);
             color: #fff !important;
@@ -264,7 +264,7 @@
 
             border: none;
             padding: .625rem;
-            font-size: 14px;
+            font-size: 0.875rem;
 
             & .table-heading {
                 text-transform: none;
@@ -285,7 +285,7 @@
                 border: none;
                 border-bottom: 1px var(--neutral-black-color-light) solid;
                 padding: 1rem .625rem;
-                font-size: 12px;
+                font-size: .75rem;
                 width: 14rem;
             }
 
@@ -297,9 +297,9 @@
                     border: none;
                     border-bottom: 1px var(--neutral-black-color-light) solid;
                     padding: .5rem;
-                    font-size: 12px;
+                    font-size: .75rem;
                     padding: 1rem .625rem;
-                    font-size: 12px;
+                    font-size: .75rem;
                     width: 14rem;
                 }
             }
@@ -325,12 +325,12 @@
             color: #fff;
             border-color: #4a5055;
             padding: .5rem 1.5rem;
-            font-size: 12px;
+            font-size: 0.75rem;
 
             & .table-status-badge-green {
                 background: #EEF6EE;
                 color: #006100;
-                font-size: 12px;
+                font-size: 0.75rem;
                 font-style: normal;
                 font-weight: 400;
                 line-height: normal;
@@ -345,7 +345,7 @@
             & .table-status-badge-yellow {
                 background: #FFEFD6;
                 color: #943600;
-                font-size: 12px;
+                font-size: 0.75rem;
                 font-style: normal;
                 font-weight: 400;
                 line-height: normal;
@@ -360,7 +360,7 @@
             & .table-status-badge-red {
                 background-color: #FAEAEA;
                 color: #ea0000;
-                font-size: 12px;
+                font-size: 0.75rem;
                 font-style: normal;
                 font-weight: 400;
                 line-height: normal;
@@ -379,12 +379,12 @@
             & td {
                 border-color: #343a40;
                 padding: .5rem 1.5rem;
-                font-size: 12px;
+                font-size: 0.75rem;
 
                 & .table-status-badge-green {
                     background: #EEF6EE;
                     color: #006100;
-                    font-size: 12px;
+                    font-size: 0.75rem;
                     font-style: normal;
                     font-weight: 400;
                     line-height: normal;
@@ -399,7 +399,7 @@
                 & .table-status-badge-yellow {
                     background: #FFEFD6;
                     color: #943600;
-                    font-size: 12px;
+                    font-size: 0.75rem;
                     font-style: normal;
                     font-weight: 400;
                     line-height: normal;
@@ -413,7 +413,7 @@
                 & .table-status-badge-red {
                     background-color: #FAEAEA;
                     color: #ea0000;
-                    font-size: 12px;
+                    font-size: 0.75rem;
                     font-style: normal;
                     font-weight: 400;
                     line-height: normal;

--- a/src/app/components/table/table.component.scss
+++ b/src/app/components/table/table.component.scss
@@ -151,6 +151,7 @@
 
         & .p-datatable-thead>tr>th {
             padding: .5rem .25rem;
+            font-size: 14px;
             // background-color: #ececec;
             background-color: var(--primary-color);
             color: #fff !important;
@@ -263,6 +264,7 @@
 
             border: none;
             padding: .625rem;
+            font-size: 14px;
 
             & .table-heading {
                 text-transform: none;
@@ -283,7 +285,7 @@
                 border: none;
                 border-bottom: 1px var(--neutral-black-color-light) solid;
                 padding: 1rem .625rem;
-                font-size: .75rem;
+                font-size: 12px;
                 width: 14rem;
             }
 
@@ -295,9 +297,9 @@
                     border: none;
                     border-bottom: 1px var(--neutral-black-color-light) solid;
                     padding: .5rem;
-                    font-size: .75rem;
+                    font-size: 12px;
                     padding: 1rem .625rem;
-                    font-size: .75rem;
+                    font-size: 12px;
                     width: 14rem;
                 }
             }


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1015

Issue:
Table text sizing did not meet the accessibility expectation from the Customer Engagement review:
Body rows were not consistently defined to the required minimum readable size standard.
Column headers were not consistently 2px larger than row text.
This affected shared table rendering in:
table.component.scss
table-v2.component.scss

Rootcause:
Typography rules were fragmented and inconsistent across multiple selectors/themes:
Row text used mixed units and repeated declarations (for example, .75rem and repeated td font-size blocks), causing inconsistent effective sizing.
Header cells did not have a clear, enforced font-size hierarchy relative to row cells in all table variants.

Fix:
Standardized table typography in both shared table styles:
Set table row cell text to 12px minimum.
Set table header text to 14px, preserving the +2px hierarchy over row text.
Applied the change to both core table implementations so behavior is consistent across pages and report styles.

Build:
<img width="816" height="237" alt="image" src="https://github.com/user-attachments/assets/81dc7e07-44d0-4d3b-8243-41fd2270e877" />
