### PR TITLE
feat: table logic for Subsystems tab now only appears when the system…

### DIFF
--- a/src/app/views/systems/systems/details/systems-details.component.html
+++ b/src/app/views/systems/systems/details/systems-details.component.html
@@ -360,7 +360,7 @@
           </div>
         </div>
       }
-      @if (isSubsystemsTabActive) {
+      @if (isSubsystemsTabActive && showSubsystemsTab()) {
         <div class="tab-container">
           <div class="overall-data-container">
             <div class="main-data-container">

--- a/src/app/views/systems/systems/details/systems-details.component.ts
+++ b/src/app/views/systems/systems/details/systems-details.component.ts
@@ -334,6 +334,7 @@ export class SystemsDetailsComponent implements OnInit {
   }
 
   public showSubsystemsTab(): boolean {
-    return this.detailsData?.SystemLevel?.trim()?.toLowerCase() === 'system';
+    return this.detailsData?.SystemLevel?.trim()?.toLowerCase() === 'system'
+      && this.sysSubsystemsData?.length > 0;
   }
 }


### PR DESCRIPTION
… actually has subsystem records.

Ticket:
https://github.com/GSA/GEAR3/issues/1020

Issue:
tab visibility checks only SystemLevel, not whether subsystem rows exist. I’m patching that logic now and guarding the tab pane with the same condition.

Fix:
Updated the tab-visibility logic in systems-details.component.ts so it requires both:
System Level is System
subsystem list length is greater than 0
Updated the tab-pane render guard in systems-details.component.html to use the same condition.

Build:
<img width="809" height="235" alt="image" src="https://github.com/user-attachments/assets/354cac9f-d261-492a-b97e-47930ca7764a" />
