### PR TITLE
fix: Update About page and sidenav labels to GEAR and required wording

### DIFF
--- a/src/app/components/sidebar-v2/sidebar-v2.component.ts
+++ b/src/app/components/sidebar-v2/sidebar-v2.component.ts
@@ -54,8 +54,8 @@ export class SidebarV2Component {
     { text: 'Glossary', route: '/glossary' },
     { text: 'Data Dictionary', route: '/data_dictionary' },
     { text: 'API Documentation', href: 'https://gsa.github.io/GEAR-Documentation/api-docs/', icon: 'fas fa-external-link-alt' },
-    { text: 'Overview', route: '/about/overview' },
-    { text: 'Data', route: '/about/data' },
+    { text: 'About GEAR', route: '/about/overview' },
+    { text: 'Data Strategy', route: '/about/data' },
     { text: 'Systems Rationalization', route: '/about/sysRat' }
   ];
   

--- a/src/app/views/main/about/about.component.html
+++ b/src/app/views/main/about/about.component.html
@@ -1,12 +1,12 @@
 <div class="card bg-light">
   <div class="card-header text-white bg-info">
-    <h3 class="card-title my-auto">About GSA Enterprise Architecture Program</h3>
+    <h3 class="card-title my-auto">About the GEAR Program</h3>
   </div>
   <div class="card-body card-text">
     <!-- Tabs -->
     <ul id="aboutTabs" class="nav nav-tabs">
       <li class="nav-item">
-        <a class="nav-link" [class.active]="isActiveTab('overview')" (click)="onTabClick('overview', $event)" href="#overview"> Overview</a>
+        <a class="nav-link" [class.active]="isActiveTab('overview')" (click)="onTabClick('overview', $event)" href="#overview"> About GEAR</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" [class.active]="isActiveTab('data')" (click)="onTabClick('data', $event)" href="#data"> Data</a>


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1010

Issue:
The About page and its left-side “Additional Information” menu used older GSA terminology. The tab label still showed “Overview,” the page header still said “About GSA Enterprise Architecture Program,” and the sidenav still listed “Overview” and “Data.”

Root Cause:
These were hard-coded UI strings in about.component.html and sidebar-v2.component.ts. The routes were already correct; only the displayed labels were out of date.

Fix:
Updated the About page copy to match the requested GEAR wording:

“About GSA Enterprise Architecture Program” → “About the GEAR Program”
“Overview” tab → “About GEAR”
“Overview” sidenav item → “About GEAR”
“Data” sidenav item → “Data Strategy”

Build:
<img width="820" height="239" alt="image" src="https://github.com/user-attachments/assets/dba7eee4-3279-4f2a-a1f5-d23a23ccdf0f" />
