### PR TITLE
fix: changed the subsystems table to use an emit-only row click path

### DIFF
--- a/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -56,9 +56,12 @@ export class BreadcrumbComponent implements OnInit {
     public ngOnInit(): void {
         this.route.queryParams.subscribe(params => {
             this.tableSearchTerm = params['tableSearchTerm'];
+            this.buildBreadcrumb();
         });
 
-        this.buildBreadcrumb();
+        this.route.paramMap.subscribe(() => {
+            this.buildBreadcrumb();
+        });
     }
 
     private buildBreadcrumb(): void {

--- a/src/app/views/systems/systems/details/systems-details.component.html
+++ b/src/app/views/systems/systems/details/systems-details.component.html
@@ -366,7 +366,7 @@
             <div class="main-data-container">
               <div class="sub-content full-width">
                 <span class="sub-header">Related Subsystems</span>
-                <app-table visibleColumnStorageKey="systems-related-subsystems" defaultSortField="Name" [localTableData]="sysSubsystemsData" [isLocal]="true" [tableCols]="relatedSystemsCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="systems" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onRelatedSubsystemsRowClick($event)"></app-table>
+                <app-table visibleColumnStorageKey="systems-related-subsystems" defaultSortField="Name" [localTableData]="sysSubsystemsData" [isLocal]="true" [tableCols]="relatedSystemsCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="accessForms" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onRelatedSubsystemsRowClick($event)"></app-table>
               </div>
             </div>
           </div>

--- a/src/app/views/systems/systems/details/systems-details.component.ts
+++ b/src/app/views/systems/systems/details/systems-details.component.ts
@@ -73,6 +73,7 @@ export class SystemsDetailsComponent implements OnInit {
 
   public ngOnInit(): void {
     this.route.paramMap.subscribe(params => {
+      this.resetDetailsState();
       this.systemId = +params.get('sysID');
 
       forkJoin([
@@ -159,6 +160,24 @@ export class SystemsDetailsComponent implements OnInit {
       // });
 
     });
+  }
+
+  private resetDetailsState(): void {
+    this.isDataReady = false;
+
+    this.isOverviewTabActive = true;
+    this.isBusinessTabActive = false;
+    this.isTechnicalTabActive = false;
+    this.isRecordsTabActive = false;
+    this.isWebsitesTabActive = false;
+    this.isSubsystemsTabActive = false;
+
+    this.systemTimeData = [];
+    this.sysCapabilitiesData = [];
+    this.sysTechnologiesData = [];
+    this.sysRecordsData = [];
+    this.sysWebsitesData = [];
+    this.sysSubsystemsData = [];
   }
 
   public getStatusClass(status: string): string {


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1025

Issue:
Clicking a subsystem row from a business system detail page changed the header/title, but it did not load the subsystem details page correctly.

Root cause:

The subsystem table was using the shared systems click behavior, which routed through the legacy system/modal flow instead of a clean route navigation.
That behavior updated the page title/context, but did not reliably trigger the subsystem detail view load.

Build:
<img width="820" height="239" alt="image" src="https://github.com/user-attachments/assets/5dfcedfd-1d6f-4d5a-8363-2d31d8a2852a" />
