### PR TITLE
fix: restore search filter on back-navigation when columns load async

### DIFF
--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -482,9 +482,16 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
   private applyPendingSearch(): boolean {
     const term = this.urlSearchTerm || this.tableSearchControl.value?.trim();
     if (term && this.originalTableData.length > 0) {
-      this.urlSearchTerm = '';
+      const searchableColumns = this.tableCols.filter(col => col.field && col.showColumn !== false);
+
       this.tableSearchControl.patchValue(term, { emitEvent: false });
+
+      if (searchableColumns.length === 0) {
+        return false;
+      }
+
       this.onTableSearch(term);
+      this.urlSearchTerm = '';
       return true;
     }
     return false;


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/947

Root Cause: 
On back-navigation, applyPendingSearch() ran when data arrived but before tableCols was loaded. onTableSearch("jonah") found zero searchable columns, scored every row as 0, returned an empty table, and cleared the pending search term — so when columns finally arrived there was nothing left to re-apply.

Fix:
Guard applyPendingSearch() to bail out (return false) if tableCols is still empty, letting ngOnChanges retry once columns arrive.

Build:
<img width="809" height="229" alt="image" src="https://github.com/user-attachments/assets/2e5a0697-22ca-43cc-a4d7-1a9a713eaf10" />
