### PR TITLE
Reordered logic in table so saved/default column visibility is applie…

### DIFF
--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -200,8 +200,6 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
 
     if (changes.tableCols && this.tableCols && this.tableCols.length > 0) {
       this.captureDefaultColumnVisibility();
-      // Re-apply search if columns arrived after data (e.g., from an async API call)
-      this.applyPendingSearch();
     }
 
     const savedColumns = this.getSavedVisibleColumnFields();
@@ -209,6 +207,11 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
       this.applySavedColumnVisibility(savedColumns);
     } else {
       this.resetVisibleColumnsToDefault();
+    }
+
+    if (changes.tableCols && this.tableCols && this.tableCols.length > 0) {
+      // Re-apply search after visible columns have been restored.
+      this.applyPendingSearch();
     }
     
     // Handle tableCols changes (e.g., when switching tabs)


### PR DESCRIPTION
…d first.

Ticekt:
https://github.com/GSA/GEAR3/issues/947

Rootcause:
On return to systems list, pending search was replayed before saved visible columns were restored.
If you searched by a newly-added visible column like Technical POC, replay could run without that column in searchable set, return empty, and cache the empty result.

Fix:
Reordered logic in table.component.ts:196 so saved/default column visibility is applied first, then pending search is replayed.
Hardened pending search in table.component.ts:482 to not consume the URL search term until searchable columns are actually available.

Build:
<img width="807" height="226" alt="image" src="https://github.com/user-attachments/assets/32db1625-aec8-428d-b959-9532693e52d4" />
