### PR TITLE
fix: Added explicit npm overrides to force patched Undici lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15755,6 +15755,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
     "webpack-bundle-analyzer": "^4.6.1"
   },
   "overrides": {
-    "undici": "^7.28.0"
+    "undici@^6": "6.27.0",
+    "undici@^7": "7.28.0",
+    "undici@^8": "8.5.0"
   }
 }


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1012

Issue:
Undici vulnerability (CVE-2026-12151) kept appearing in scans even after initial remediation attempts.

Root cause:
The project had transitive dependencies requesting vulnerable Undici ranges (for example from Angular build tooling and node-gyp). Also, scan results can persist when the dev environment still has stale node_modules or scanner cache, so the tool reports old metadata instead of current resolved installs.

Fix:
Updated dependency enforcement to patched versions in package.json:

undici major 6 pinned to 6.27.0
undici major 7 pinned to 7.28.0
undici major 8 pinned to 8.5.0
Then regenerated and reinstalled dependencies so resolved and installed versions are patched in package-lock.json.

Build:
<img width="822" height="243" alt="image" src="https://github.com/user-attachments/assets/7ef01e68-7c35-4535-935b-1ef689de9063" />
