### PR TITLE
feat: dashboard include past-due expirations in FISMA and IT Standard…

### DIFF
--- a/api/controllers/fisma.controller.js
+++ b/api/controllers/fisma.controller.js
@@ -222,6 +222,12 @@ exports.getExpiringWeek = (req, res) => {
   res = ctrl.sendQuery(query, `Expiring FISMA this week`, res);
 };
 
+exports.getPastDue = (req, res) => {
+  var query = fs.readFileSync(path.join(__dirname, queryPath, `GET/get_fisma_past_due.sql`)).toString();
+
+  res = ctrl.sendQuery(query, `Past due FISMA`, res);
+};
+
 exports.getFilterTotals = (req, res) => {  
   var query = fs.readFileSync(path.join(__dirname, queryPath, `GET/get_fisma_filter_totals.sql`)).toString();
 

--- a/api/controllers/it-standards.controller.js
+++ b/api/controllers/it-standards.controller.js
@@ -644,6 +644,12 @@ exports.getExpiringWeek = (req, res) => {
   res = ctrl.sendQuery(query, `Expiring IT standards this week`, res);
 };
 
+exports.getPastDue = (req, res) => {
+  var query = fs.readFileSync(path.join(__dirname, queryPath, `GET/get_it-standards_past_due.sql`)).toString();
+
+  res = ctrl.sendQuery(query, `Past due IT standards`, res);
+};
+
 exports.getRetiredTotals = (req, res) => {
   var query = fs.readFileSync(path.join(__dirname, queryPath, `GET/get_it-standards_retired_totals.sql`)).toString();
 

--- a/api/models/it-standards.model.ts
+++ b/api/models/it-standards.model.ts
@@ -26,6 +26,7 @@ export class ITStandards {
   public SoftwareProductName: string = null;
   public SoftwareVersionName: string = null;
   public SoftwareReleaseName: string = null;
+  public StatusId: number = null;
   public Status: string = null;
   public DeploymentType: string = null;
   public StandardType: string = null;

--- a/api/queries/GET/get_fisma_past_due.sql
+++ b/api/queries/GET/get_fisma_past_due.sql
@@ -1,0 +1,5 @@
+SELECT COUNT(*) AS Total
+FROM obj_fisma_archer AS fisma
+WHERE fisma.`ex:ATO_Expiration_Date` < CURDATE()
+    AND fisma.`ex:SystemLevel` = 'System'
+    AND (fisma.`ex:Status` = 'Active' OR fisma.`ex:Status` = 'Pending');

--- a/api/queries/GET/get_it-standards.sql
+++ b/api/queries/GET/get_it-standards.sql
@@ -30,6 +30,7 @@ SELECT
   tech.softwareReleaseName                        AS SoftwareReleaseName,
   IFNULL(CONCAT(tech.manufacturerName, ' - ', tech.softwareProductName), tech.Keyname) AS ManufacturerSoftwareProductName,
 
+  tech.obj_technology_status_Id                  AS StatusId,
   obj_technology_status.Keyname                   AS Status,
   obj_deployment_type.Keyname                     AS DeploymentType,
   obj_standard_type.Keyname                       AS StandardType,

--- a/api/queries/GET/get_it-standards_expiring_quarter.sql
+++ b/api/queries/GET/get_it-standards_expiring_quarter.sql
@@ -1,6 +1,8 @@
 SELECT COUNT(*) AS Total
 FROM obj_technology AS tech
+LEFT JOIN obj_standard_type ON tech.obj_standard_type_Id = obj_standard_type.Id
 WHERE tech.Approved_Status_Expiration_Date >= CURDATE() AND tech.Approved_Status_Expiration_Date <= DATE_ADD(CURDATE(), INTERVAL 3 MONTH)
+    AND obj_standard_type.Keyname LIKE 'Software'
         AND (tech.obj_technology_status_Id = 11 
             OR tech.obj_technology_status_Id = 2 
             OR tech.obj_technology_status_Id = 6 

--- a/api/queries/GET/get_it-standards_expiring_week.sql
+++ b/api/queries/GET/get_it-standards_expiring_week.sql
@@ -1,6 +1,8 @@
 SELECT COUNT(*) AS Total
 FROM obj_technology AS tech
+LEFT JOIN obj_standard_type ON tech.obj_standard_type_Id = obj_standard_type.Id
 WHERE tech.Approved_Status_Expiration_Date >= CURDATE() AND tech.Approved_Status_Expiration_Date <= DATE_ADD(CURDATE(), INTERVAL 7 DAY)
+    AND obj_standard_type.Keyname LIKE 'Software'
         AND (tech.obj_technology_status_Id = 11 
             OR tech.obj_technology_status_Id = 2 
             OR tech.obj_technology_status_Id = 6 

--- a/api/queries/GET/get_it-standards_past_due.sql
+++ b/api/queries/GET/get_it-standards_past_due.sql
@@ -1,0 +1,7 @@
+SELECT COUNT(*) AS Total
+FROM obj_technology AS tech
+WHERE tech.Approved_Status_Expiration_Date < CURDATE()
+        AND (tech.obj_technology_status_Id = 11
+            OR tech.obj_technology_status_Id = 2
+            OR tech.obj_technology_status_Id = 6
+            OR tech.obj_technology_status_Id = 9);  -- accounting for any status that is technically approved (Approved, Pilot, Exception, Sunsetting)

--- a/api/queries/GET/get_it-standards_past_due.sql
+++ b/api/queries/GET/get_it-standards_past_due.sql
@@ -1,6 +1,8 @@
 SELECT COUNT(*) AS Total
 FROM obj_technology AS tech
+LEFT JOIN obj_standard_type ON tech.obj_standard_type_Id = obj_standard_type.Id
 WHERE tech.Approved_Status_Expiration_Date < CURDATE()
+    AND obj_standard_type.Keyname LIKE 'Software'
         AND (tech.obj_technology_status_Id = 11
             OR tech.obj_technology_status_Id = 2
             OR tech.obj_technology_status_Id = 6

--- a/api/routes/fisma.routes.js
+++ b/api/routes/fisma.routes.js
@@ -24,6 +24,9 @@ router.route('/expiring_quarter')
 router.route('/expiring_week')
   .get(fismaCtrl.getExpiringWeek);
 
+router.route('/past_due')
+  .get(fismaCtrl.getPastDue);
+
 router.route('/filter_totals')
   .get(fismaCtrl.getFilterTotals);
 

--- a/api/routes/it-standards.routes.js
+++ b/api/routes/it-standards.routes.js
@@ -66,6 +66,9 @@ router.route('/expiring_quarter')
 router.route('/expiring_week')
   .get(itsCtrl.getExpiringWeek);
 
+router.route('/past_due')
+  .get(itsCtrl.getPastDue);
+
 router.route('/filter_totals')
   .get(itsCtrl.getFilterTotals);
   

--- a/src/app/services/apis/api.service.ts
+++ b/src/app/services/apis/api.service.ts
@@ -220,6 +220,14 @@ export class ApiService {
         catchError(this.handleError<any>(`GET FISMA expiring this week`)));
   }
 
+  public getFismaPastDue(): Observable<any> {
+    return this.http
+      .get<any>(this.fismaUrl + '/past_due')
+      .pipe(
+        map(r => r[0].Total),
+        catchError(this.handleError<any>(`GET FISMA past due`)));
+  }
+
   public getFismaFilterTotals(): Observable<any> {
     return this.http
     .get<any>(this.fismaUrl + '/filter_totals')
@@ -861,6 +869,14 @@ export class ApiService {
       .pipe(
         map(r => r[0][0].Total),
         catchError(this.handleError<any>(`GET IT Standards expiring this week`)));
+  }
+
+  public getITStandardsPastDue(): Observable<any> {
+    return this.http
+      .get<any>(this.techUrl + '/past_due')
+      .pipe(
+        map(r => r[0][0].Total),
+        catchError(this.handleError<any>(`GET IT Standards past due`)));
   }
 
   public getITStandardsRelatedSystems(id: number): Observable<System[]> {

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -17,16 +17,16 @@
           <a (click)="viewAllFisma()" class="view-all-link" tabindex="0" (keydown.enter)="viewAllFisma()" (keydown.space)="viewAllFisma()">View All</a>
         </div>
         <span class="quick-view-text">FISMA Systems Expiring by {{ getExpiringDate() }}</span>
-        <div class="quick-view-expiring-text-container" [ngClass]="{'neutral-message': (fismaExpiringThisWeek || 0) === 0}">
-          @if ((fismaExpiringThisWeek || 0) > 0) {
+        <div class="quick-view-expiring-text-container" [ngClass]="{'neutral-message': getFismaExpiryAlertCount() === 0}">
+          @if (getFismaExpiryAlertCount() > 0) {
             <i class="expire-icon fas fa-exclamation-triangle"></i>
           }
-          <span class="expire-text" [ngClass]="{'positive-expire-text' : fismaExpiringThisWeek > 0, 'neutral-text': (fismaExpiringThisWeek || 0) === 0}">
-            @if ((fismaExpiringThisWeek || 0) > 0) {
-              <span tabindex="0" (click)="viewExpiringFisma()" (keydown.enter)="viewExpiringFisma()" (keydown.space)="viewExpiringFisma()">{{ fismaExpiringThisWeek || 0 }} items expiring within 7 days</span>
+          <span class="expire-text" [ngClass]="{'positive-expire-text' : getFismaExpiryAlertCount() > 0, 'neutral-text': getFismaExpiryAlertCount() === 0}">
+            @if (getFismaExpiryAlertCount() > 0) {
+              <span tabindex="0" (click)="viewExpiringFisma()" (keydown.enter)="viewExpiringFisma()" (keydown.space)="viewExpiringFisma()">{{ getFismaExpiryAlertMessage() }}</span>
             }
-            @if ((fismaExpiringThisWeek || 0) === 0) {
-              <span>No items expiring within 7 days</span>
+            @if (getFismaExpiryAlertCount() === 0) {
+              <span>{{ getFismaExpiryAlertMessage() }}</span>
             }
           </span>
         </div>
@@ -69,16 +69,16 @@
           <a (click)="viewAllITStandards()" class="view-all-link" tabindex="0" (keydown.enter)="viewAllITStandards()" (keydown.space)="viewAllITStandards()">View All</a>
         </div>
         <span class="quick-view-text">IT Standards Expiring by {{ getExpiringDate() }}</span>
-        <div class="quick-view-expiring-text-container" [ngClass]="{'neutral-message': (standardsExpiringThisWeek || 0) === 0}">
-          @if ((standardsExpiringThisWeek || 0) > 0) {
+        <div class="quick-view-expiring-text-container" [ngClass]="{'neutral-message': getStandardsExpiryAlertCount() === 0}">
+          @if (getStandardsExpiryAlertCount() > 0) {
             <i class="expire-icon fas fa-exclamation-triangle"></i>
           }
-          <span class="expire-text" [ngClass]="{'positive-expire-text' : standardsExpiringThisWeek > 0, 'neutral-text': (standardsExpiringThisWeek || 0) === 0}">
-            @if ((standardsExpiringThisWeek || 0) > 0) {
-              <span tabindex="0" (click)="viewExpiringITStandards()" (keydown.enter)="viewExpiringITStandards()" (keydown.space)="viewExpiringITStandards()">{{ standardsExpiringThisWeek || 0 }} items expiring within 7 days</span>
+          <span class="expire-text" [ngClass]="{'positive-expire-text' : getStandardsExpiryAlertCount() > 0, 'neutral-text': getStandardsExpiryAlertCount() === 0}">
+            @if (getStandardsExpiryAlertCount() > 0) {
+              <span tabindex="0" (click)="viewExpiringITStandards()" (keydown.enter)="viewExpiringITStandards()" (keydown.space)="viewExpiringITStandards()">{{ getStandardsExpiryAlertMessage() }}</span>
             }
-            @if ((standardsExpiringThisWeek || 0) === 0) {
-              <span>No items expiring within 7 days</span>
+            @if (getStandardsExpiryAlertCount() === 0) {
+              <span>{{ getStandardsExpiryAlertMessage() }}</span>
             }
           </span>
         </div>

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -18,17 +18,23 @@
         </div>
         <span class="quick-view-text">FISMA Systems Expiring by {{ getExpiringDate() }}</span>
         <div class="quick-view-expiring-text-container" [ngClass]="{'neutral-message': getFismaExpiryAlertCount() === 0}">
-          @if (getFismaExpiryAlertCount() > 0) {
-            <i class="expire-icon fas fa-exclamation-triangle"></i>
-          }
-          <span class="expire-text" [ngClass]="{'positive-expire-text' : getFismaExpiryAlertCount() > 0, 'neutral-text': getFismaExpiryAlertCount() === 0}">
-            @if (getFismaExpiryAlertCount() > 0) {
-              <span tabindex="0" (click)="viewExpiringFisma()" (keydown.enter)="viewExpiringFisma()" (keydown.space)="viewExpiringFisma()">{{ getFismaExpiryAlertMessage() }}</span>
+          <div class="expire-text multi-line-expire-text" [ngClass]="{'neutral-text': getFismaExpiryAlertCount() === 0}">
+            @if ((fismaPastDue || 0) > 0) {
+              <span class="expire-link-line" tabindex="0" (click)="viewPastDueFisma()" (keydown.enter)="viewPastDueFisma()" (keydown.space)="viewPastDueFisma()">
+                <i class="expire-icon fas fa-exclamation-triangle"></i>
+                {{ getFismaPastDueLabel() }}
+              </span>
+            }
+            @if ((fismaExpiringThisWeek || 0) > 0) {
+              <span class="expire-link-line" tabindex="0" (click)="viewExpiringFisma()" (keydown.enter)="viewExpiringFisma()" (keydown.space)="viewExpiringFisma()">
+                <i class="expire-icon fas fa-exclamation-triangle"></i>
+                {{ getFismaExpiringSoonLabel() }}
+              </span>
             }
             @if (getFismaExpiryAlertCount() === 0) {
-              <span>{{ getFismaExpiryAlertMessage() }}</span>
+              <span>No items expiring within 7 days or past due</span>
             }
-          </span>
+          </div>
         </div>
       </div>
       <!-- Decommissioned Systems -->
@@ -70,17 +76,23 @@
         </div>
         <span class="quick-view-text">IT Standards Expiring by {{ getExpiringDate() }}</span>
         <div class="quick-view-expiring-text-container" [ngClass]="{'neutral-message': getStandardsExpiryAlertCount() === 0}">
-          @if (getStandardsExpiryAlertCount() > 0) {
-            <i class="expire-icon fas fa-exclamation-triangle"></i>
-          }
-          <span class="expire-text" [ngClass]="{'positive-expire-text' : getStandardsExpiryAlertCount() > 0, 'neutral-text': getStandardsExpiryAlertCount() === 0}">
-            @if (getStandardsExpiryAlertCount() > 0) {
-              <span tabindex="0" (click)="viewExpiringITStandards()" (keydown.enter)="viewExpiringITStandards()" (keydown.space)="viewExpiringITStandards()">{{ getStandardsExpiryAlertMessage() }}</span>
+          <div class="expire-text multi-line-expire-text" [ngClass]="{'neutral-text': getStandardsExpiryAlertCount() === 0}">
+            @if ((standardsPastDue || 0) > 0) {
+              <span class="expire-link-line" tabindex="0" (click)="viewPastDueITStandards()" (keydown.enter)="viewPastDueITStandards()" (keydown.space)="viewPastDueITStandards()">
+                <i class="expire-icon fas fa-exclamation-triangle"></i>
+                {{ getStandardsPastDueLabel() }}
+              </span>
+            }
+            @if ((standardsExpiringThisWeek || 0) > 0) {
+              <span class="expire-link-line" tabindex="0" (click)="viewExpiringITStandards()" (keydown.enter)="viewExpiringITStandards()" (keydown.space)="viewExpiringITStandards()">
+                <i class="expire-icon fas fa-exclamation-triangle"></i>
+                {{ getStandardsExpiringSoonLabel() }}
+              </span>
             }
             @if (getStandardsExpiryAlertCount() === 0) {
-              <span>{{ getStandardsExpiryAlertMessage() }}</span>
+              <span>No items expiring within 7 days or past due</span>
             }
-          </span>
+          </div>
         </div>
       </div>
       <!-- Retired IT Standards -->

--- a/src/app/views/dashboard/dashboard.component.scss
+++ b/src/app/views/dashboard/dashboard.component.scss
@@ -123,6 +123,38 @@
             & a {
               color: #8a4300;
             }
+
+            &.multi-line-expire-text {
+              display: flex;
+              flex-direction: column;
+              align-items: flex-start;
+              gap: 0.15rem;
+              width: 100%;
+            }
+
+            & .expire-link-line {
+              display: flex;
+              align-items: center;
+              gap: 0.25rem;
+              text-decoration-line: underline;
+              cursor: pointer;
+              width: fit-content;
+              transition: transform 120ms ease, filter 120ms ease;
+
+              &:hover {
+                filter: brightness(0.9);
+              }
+
+              &:active {
+                transform: translateY(1px) scale(0.99);
+              }
+
+              &:focus-visible {
+                outline: 2px solid rgba(0, 95, 204, 0.45);
+                outline-offset: 2px;
+                border-radius: 2px;
+              }
+            }
           }
   
           & .positive-expire-text {

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -137,12 +137,14 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
 
   public fismaExpiringThisQuarter: number = 0;
   public fismaExpiringThisWeek: number = 0;
+  public fismaPastDue: number = 0;
 
   public decommissionedSystemsLast6Months: number = 0;
   public decommissionedSystemsLastMonth: number = 0;
 
   public standardsExpiringThisQuarter: number = 0;
   public standardsExpiringThisWeek: number = 0;
+  public standardsPastDue: number = 0;
 
   public retiredITStandardsLast6Months: number = 0;
   public retiredITStandardsLast7Days: number = 0;
@@ -160,8 +162,10 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     forkJoin([
       this.apiService.getITStandardsExpiringThisQuarter(),
       this.apiService.getITStandardsExpiringThisWeek(),
+      this.apiService.getITStandardsPastDue(),
       this.apiService.getFismaExpiringThisQuarter(),
       this.apiService.getFismaExpiringThisWeek(),
+      this.apiService.getFismaPastDue(),
       this.apiService.getDecommissionedSystemTotals(),
       this.apiService.getRetiredStandardsTotals(),
       this.apiService.getDataDictionaryByReportName('IT Standards List')
@@ -169,16 +173,20 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
       ([
         standardsExpiringQuarter,
         standardsExpiringWeek,
+        standardsPastDue,
         fismaExpiringQuarter,
         fismaExpiringWeek,
+        fismaPastDue,
         decommissionedSystemTotals,
         RetiredStandardTotals,
         definitions
       ]) => {
         this.standardsExpiringThisQuarter = standardsExpiringQuarter || 0;
         this.standardsExpiringThisWeek = standardsExpiringWeek || 0;
+        this.standardsPastDue = standardsPastDue || 0;
         this.fismaExpiringThisQuarter = fismaExpiringQuarter || 0;
         this.fismaExpiringThisWeek = fismaExpiringWeek || 0;
+        this.fismaPastDue = fismaPastDue || 0;
 
         this.decommissionedSystemsLast6Months = decommissionedSystemTotals?.DecommissionedSystemsLastSixMonths || 0;
         this.decommissionedSystemsLastMonth = decommissionedSystemTotals?.DecommissionedSystemsLastMonth || 0;
@@ -394,16 +402,16 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public viewExpiringFisma():void {
-    this.analyticsService.logClickEvent('/FISMA', 'Dashboard FISMA expiring this week');
-    this.router.navigate(['/FISMA'], { queryParams: { expiringWithinDays: '7' } });
+    this.analyticsService.logClickEvent('/FISMA', 'Dashboard FISMA expiring this week or past due');
+    this.router.navigate(['/FISMA'], { queryParams: { expiringWithinDays: '7', includePastDue: 'true' } });
   }
   public viewDecommissionedSystems(): void {
     this.analyticsService.logClickEvent('/systems', 'Dashboard decommissioned systems this week');
     this.router.navigate(['/systems'], { queryParams: { decommissionedWithinMonths: '1' } });
   }
   public viewExpiringITStandards(): void {
-    this.analyticsService.logClickEvent('/it_standards', 'Dashboard IT standards expiring this week');
-    this.router.navigate(['/it_standards'], { queryParams: { expiringWithinDays: '7' } });
+    this.analyticsService.logClickEvent('/it_standards', 'Dashboard IT standards expiring this week or past due');
+    this.router.navigate(['/it_standards'], { queryParams: { expiringWithinDays: '7', includePastDue: 'true' } });
   }
   public viewRecentRetiredITStandards(): void {
     this.analyticsService.logClickEvent('/it_standards', 'Dashboard IT standards retired in past week');
@@ -421,5 +429,44 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
       this.router.navigate(['/systems'], {queryParams: { systemCSP: barName } });
     } 
 
+  }
+
+  public getFismaExpiryAlertCount(): number {
+    return (this.fismaExpiringThisWeek || 0) + (this.fismaPastDue || 0);
+  }
+
+  public getStandardsExpiryAlertCount(): number {
+    return (this.standardsExpiringThisWeek || 0) + (this.standardsPastDue || 0);
+  }
+
+  public getFismaExpiryAlertMessage(): string {
+    return this.buildExpiryAlertMessage(this.fismaExpiringThisWeek, this.fismaPastDue);
+  }
+
+  public getStandardsExpiryAlertMessage(): string {
+    return this.buildExpiryAlertMessage(this.standardsExpiringThisWeek, this.standardsPastDue);
+  }
+
+  private buildExpiryAlertMessage(expiringCount: number, pastDueCount: number): string {
+    const expiring = expiringCount || 0;
+    const pastDue = pastDueCount || 0;
+
+    if (expiring === 0 && pastDue === 0) {
+      return 'No items expiring within 7 days or past due';
+    }
+
+    const parts: string[] = [];
+    if (expiring > 0) {
+      parts.push(`${this.itemLabel(expiring)} expiring within 7 days`);
+    }
+    if (pastDue > 0) {
+      parts.push(`${this.itemLabel(pastDue)} past due`);
+    }
+
+    return parts.join(' and ');
+  }
+
+  private itemLabel(count: number): string {
+    return `${count} item${count === 1 ? '' : 's'}`;
   }
 }

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -402,16 +402,24 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public viewExpiringFisma():void {
-    this.analyticsService.logClickEvent('/FISMA', 'Dashboard FISMA expiring this week or past due');
-    this.router.navigate(['/FISMA'], { queryParams: { expiringWithinDays: '7', includePastDue: 'true' } });
+    this.analyticsService.logClickEvent('/FISMA', 'Dashboard FISMA expiring this week');
+    this.router.navigate(['/FISMA'], { queryParams: { expiringWithinDays: '7' } });
+  }
+  public viewPastDueFisma(): void {
+    this.analyticsService.logClickEvent('/FISMA', 'Dashboard FISMA past due');
+    this.router.navigate(['/FISMA'], { queryParams: { pastDueOnly: 'true' } });
   }
   public viewDecommissionedSystems(): void {
     this.analyticsService.logClickEvent('/systems', 'Dashboard decommissioned systems this week');
     this.router.navigate(['/systems'], { queryParams: { decommissionedWithinMonths: '1' } });
   }
   public viewExpiringITStandards(): void {
-    this.analyticsService.logClickEvent('/it_standards', 'Dashboard IT standards expiring this week or past due');
-    this.router.navigate(['/it_standards'], { queryParams: { expiringWithinDays: '7', includePastDue: 'true' } });
+    this.analyticsService.logClickEvent('/it_standards', 'Dashboard IT standards expiring this week');
+    this.router.navigate(['/it_standards'], { queryParams: { expiringWithinDays: '7' } });
+  }
+  public viewPastDueITStandards(): void {
+    this.analyticsService.logClickEvent('/it_standards', 'Dashboard IT standards past due');
+    this.router.navigate(['/it_standards'], { queryParams: { pastDueOnly: 'true' } });
   }
   public viewRecentRetiredITStandards(): void {
     this.analyticsService.logClickEvent('/it_standards', 'Dashboard IT standards retired in past week');
@@ -439,34 +447,23 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     return (this.standardsExpiringThisWeek || 0) + (this.standardsPastDue || 0);
   }
 
-  public getFismaExpiryAlertMessage(): string {
-    return this.buildExpiryAlertMessage(this.fismaExpiringThisWeek, this.fismaPastDue);
-  }
-
-  public getStandardsExpiryAlertMessage(): string {
-    return this.buildExpiryAlertMessage(this.standardsExpiringThisWeek, this.standardsPastDue);
-  }
-
-  private buildExpiryAlertMessage(expiringCount: number, pastDueCount: number): string {
-    const expiring = expiringCount || 0;
-    const pastDue = pastDueCount || 0;
-
-    if (expiring === 0 && pastDue === 0) {
-      return 'No items expiring within 7 days or past due';
-    }
-
-    const parts: string[] = [];
-    if (expiring > 0) {
-      parts.push(`${this.itemLabel(expiring)} expiring within 7 days`);
-    }
-    if (pastDue > 0) {
-      parts.push(`${this.itemLabel(pastDue)} past due`);
-    }
-
-    return parts.join(' and ');
-  }
-
   private itemLabel(count: number): string {
     return `${count} item${count === 1 ? '' : 's'}`;
+  }
+
+  public getFismaPastDueLabel(): string {
+    return `${this.itemLabel(this.fismaPastDue || 0)} past due`;
+  }
+
+  public getFismaExpiringSoonLabel(): string {
+    return `${this.itemLabel(this.fismaExpiringThisWeek || 0)} expiring within 7 days`;
+  }
+
+  public getStandardsPastDueLabel(): string {
+    return `${this.itemLabel(this.standardsPastDue || 0)} past due`;
+  }
+
+  public getStandardsExpiringSoonLabel(): string {
+    return `${this.itemLabel(this.standardsExpiringThisWeek || 0)} expiring within 7 days`;
   }
 }

--- a/src/app/views/security/fisma/fisma.component.ts
+++ b/src/app/views/security/fisma/fisma.component.ts
@@ -185,12 +185,16 @@ export class FismaComponent implements OnInit {
     this.apiService.getFISMA().subscribe(fisma => {
       this.fismaData = fisma;
 
-      if (this.daysExpiring > 0) {
+      const queryParams = this.route.snapshot.queryParams;
+      const daysExpiring = Number(queryParams['expiringWithinDays'] || this.daysExpiring || 0);
+      const includePastDue = queryParams['includePastDue'] === 'true' || this.includePastDueExpirations;
+      const pastDueOnly = queryParams['pastDueOnly'] === 'true' || this.pastDueOnly;
+
+      if (daysExpiring > 0) {
         const now = new Date();
         now.setHours(0, 0, 0, 0);
         const expiringWithin = new Date(now);
-        expiringWithin.setDate(expiringWithin.getDate() + this.daysExpiring);
-        const includePastDue = this.includePastDueExpirations;
+        expiringWithin.setDate(expiringWithin.getDate() + daysExpiring);
         const expiringFiltered = fisma.filter(f => {
           if (!f.ATOExpirationDate) return false;
           const renewal = new Date(f.ATOExpirationDate);
@@ -203,7 +207,7 @@ export class FismaComponent implements OnInit {
             && (f.Status === 'Active' || f.Status === 'Pending');
         });
         this.tableService.updateReportTableData(expiringFiltered);
-      } else if (this.pastDueOnly) {
+      } else if (pastDueOnly) {
         const now = new Date();
         now.setHours(0, 0, 0, 0);
         const pastDueFiltered = fisma.filter(f => {

--- a/src/app/views/security/fisma/fisma.component.ts
+++ b/src/app/views/security/fisma/fisma.component.ts
@@ -24,6 +24,7 @@ export class FismaComponent implements OnInit {
 
   public daysExpiring: number = 0;
   public includePastDueExpirations: boolean = false;
+  public pastDueOnly: boolean = false;
 
   public attrDefinitions: DataDictionary[] = [];
 
@@ -172,6 +173,9 @@ export class FismaComponent implements OnInit {
       if (params['includePastDue']) {
         this.includePastDueExpirations = params['includePastDue'] === 'true';
       }
+      if (params['pastDueOnly']) {
+        this.pastDueOnly = params['pastDueOnly'] === 'true';
+      }
     });
 
     this.apiService.getDataDictionaryByReportName('FISMA Systems Inventory').subscribe(defs => {
@@ -199,6 +203,18 @@ export class FismaComponent implements OnInit {
             && (f.Status === 'Active' || f.Status === 'Pending');
         });
         this.tableService.updateReportTableData(expiringFiltered);
+      } else if (this.pastDueOnly) {
+        const now = new Date();
+        now.setHours(0, 0, 0, 0);
+        const pastDueFiltered = fisma.filter(f => {
+          if (!f.ATOExpirationDate) return false;
+          const renewal = new Date(f.ATOExpirationDate);
+          renewal.setHours(0, 0, 0, 0);
+          return renewal < now
+            && f.SystemLevel === 'System'
+            && (f.Status === 'Active' || f.Status === 'Pending');
+        });
+        this.tableService.updateReportTableData(pastDueFiltered);
       } else {
         this.fismaTabFilterted = fisma.filter(f =>
           f.Status === 'Active' && f.SystemLevel === 'System' && f.Reportable === 'Yes'

--- a/src/app/views/security/fisma/fisma.component.ts
+++ b/src/app/views/security/fisma/fisma.component.ts
@@ -23,6 +23,7 @@ export class FismaComponent implements OnInit {
   public fismaTabFilterted: FISMA[] = [];
 
   public daysExpiring: number = 0;
+  public includePastDueExpirations: boolean = false;
 
   public attrDefinitions: DataDictionary[] = [];
 
@@ -168,6 +169,9 @@ export class FismaComponent implements OnInit {
       if(params['expiringWithinDays']) {
         this.daysExpiring = +params['expiringWithinDays'];
       }
+      if (params['includePastDue']) {
+        this.includePastDueExpirations = params['includePastDue'] === 'true';
+      }
     });
 
     this.apiService.getDataDictionaryByReportName('FISMA Systems Inventory').subscribe(defs => {
@@ -182,11 +186,15 @@ export class FismaComponent implements OnInit {
         now.setHours(0, 0, 0, 0);
         const expiringWithin = new Date(now);
         expiringWithin.setDate(expiringWithin.getDate() + this.daysExpiring);
+        const includePastDue = this.includePastDueExpirations;
         const expiringFiltered = fisma.filter(f => {
           if (!f.ATOExpirationDate) return false;
           const renewal = new Date(f.ATOExpirationDate);
           renewal.setHours(0, 0, 0, 0);
-          return renewal >= now && renewal <= expiringWithin
+          const isInWindow = includePastDue
+            ? renewal <= expiringWithin
+            : (renewal >= now && renewal <= expiringWithin);
+          return isInWindow
             && f.SystemLevel === 'System'
             && (f.Status === 'Active' || f.Status === 'Pending');
         });

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -41,6 +41,7 @@ export class ItStandardsComponent implements OnInit {
   public daysExpiring: number = 0;
   public daysRetired: number = 0;
   public includePastDueExpirations: boolean = false;
+  public pastDueOnly: boolean = false;
 
   public isDataReady: boolean = false;
 
@@ -158,6 +159,9 @@ export class ItStandardsComponent implements OnInit {
       }
       if (params['includePastDue']) {
         this.includePastDueExpirations = params['includePastDue'] === 'true';
+      }
+      if (params['pastDueOnly']) {
+        this.pastDueOnly = params['pastDueOnly'] === 'true';
       }
       if(params['retiredWithinDays']) {
         this.daysRetired = +params['retiredWithinDays'];
@@ -378,13 +382,18 @@ export class ItStandardsComponent implements OnInit {
       this.itStandardsDataTabFilterted = this.setCondtionStatus(i);
       this.itStandardsDataChipFilterted = this.setCondtionStatus(i);
 
-      if(this.daysExpiring > 0) {
+      const queryParams = this.route.snapshot.queryParams;
+      const daysExpiring = Number(queryParams['expiringWithinDays'] || this.daysExpiring || 0);
+      const daysRetired = Number(queryParams['retiredWithinDays'] || this.daysRetired || 0);
+      const includePastDue = queryParams['includePastDue'] === 'true' || this.includePastDueExpirations;
+      const pastDueOnly = queryParams['pastDueOnly'] === 'true' || this.pastDueOnly;
+
+      if(daysExpiring > 0) {
         const now = new Date(); // Current date and time
         now.setUTCHours(0, 0, 0, 0);
         const expiringWithin = new Date();
-        expiringWithin.setDate(now.getDate() + this.daysExpiring); // number of days set in the url
+        expiringWithin.setDate(now.getDate() + daysExpiring); // number of days set in the url
         expiringWithin.setUTCHours(0, 0, 0, 0);
-        const includePastDue = this.includePastDueExpirations;
         const expiringFiltered: ITStandards[] = [];
         i.forEach(x => {
           let renewal = new Date(x.ApprovalExpirationDate);
@@ -398,11 +407,24 @@ export class ItStandardsComponent implements OnInit {
         });
         this.tableService.updateReportTableData(expiringFiltered);
         this.tableService.updateReportTableDataReadyStatus(true);
-      } else if(this.daysRetired > 0) {
+      } else if (pastDueOnly) {
+        const now = new Date();
+        now.setUTCHours(0, 0, 0, 0);
+        const pastDueFiltered: ITStandards[] = [];
+        i.forEach(x => {
+          let renewal = new Date(x.ApprovalExpirationDate);
+          renewal.setUTCHours(0, 0, 0, 0);
+          if (x.ApprovalExpirationDate && renewal < now) {
+            pastDueFiltered.push(x);
+          }
+        });
+        this.tableService.updateReportTableData(pastDueFiltered);
+        this.tableService.updateReportTableDataReadyStatus(true);
+      } else if(daysRetired > 0) {
         const now = new Date(); // Current date and time
         now.setUTCHours(0, 0, 0, 0);
         const expiredWithin = new Date();
-        expiredWithin.setDate(now.getDate() - this.daysRetired); // number of days set in the url
+        expiredWithin.setDate(now.getDate() - daysRetired); // number of days set in the url
         expiredWithin.setUTCHours(0, 0, 0, 0);
         const expiringFiltered: ITStandards[] = [];
         i.forEach(x => {

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -40,6 +40,7 @@ export class ItStandardsComponent implements OnInit {
 
   public daysExpiring: number = 0;
   public daysRetired: number = 0;
+  public includePastDueExpirations: boolean = false;
 
   public isDataReady: boolean = false;
 
@@ -154,6 +155,9 @@ export class ItStandardsComponent implements OnInit {
       }
       if(params['expiringWithinDays']) {
         this.daysExpiring = +params['expiringWithinDays'];
+      }
+      if (params['includePastDue']) {
+        this.includePastDueExpirations = params['includePastDue'] === 'true';
       }
       if(params['retiredWithinDays']) {
         this.daysRetired = +params['retiredWithinDays'];
@@ -380,11 +384,15 @@ export class ItStandardsComponent implements OnInit {
         const expiringWithin = new Date();
         expiringWithin.setDate(now.getDate() + this.daysExpiring); // number of days set in the url
         expiringWithin.setUTCHours(0, 0, 0, 0);
+        const includePastDue = this.includePastDueExpirations;
         const expiringFiltered: ITStandards[] = [];
         i.forEach(x => {
           let renewal = new Date(x.ApprovalExpirationDate);
           renewal.setUTCHours(0, 0, 0, 0);
-          if(x.ApprovalExpirationDate && (renewal >= now && renewal <= expiringWithin)) {
+          const isInWindow = includePastDue
+            ? renewal <= expiringWithin
+            : (renewal >= now && renewal <= expiringWithin);
+          if(x.ApprovalExpirationDate && isInWindow) {
             expiringFiltered.push(x);
           }
         });

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -401,7 +401,7 @@ export class ItStandardsComponent implements OnInit {
           const isInWindow = includePastDue
             ? renewal <= expiringWithin
             : (renewal >= now && renewal <= expiringWithin);
-          if(x.ApprovalExpirationDate && isInWindow) {
+          if(x.ApprovalExpirationDate && isInWindow && this.isInExpiringStatusScope(x)) {
             expiringFiltered.push(x);
           }
         });
@@ -414,7 +414,7 @@ export class ItStandardsComponent implements OnInit {
         i.forEach(x => {
           let renewal = new Date(x.ApprovalExpirationDate);
           renewal.setUTCHours(0, 0, 0, 0);
-          if (x.ApprovalExpirationDate && renewal < now) {
+          if (x.ApprovalExpirationDate && renewal < now && this.isInExpiringStatusScope(x)) {
             pastDueFiltered.push(x);
           }
         });
@@ -540,5 +540,14 @@ export class ItStandardsComponent implements OnInit {
       }
     });
     return itStandards;
+  }
+
+  // Keep dashboard deep-link filters consistent with backend totals query scope.
+  private isInExpiringStatusScope(standard: ITStandards): boolean {
+    return standard.Status === 'Approved'
+      || standard.Status === 'Approved with conditions'
+      || standard.Status === 'Pilot'
+      || standard.Status === 'Exception'
+      || standard.Status === 'Sunsetting';
   }
 }

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -390,14 +390,14 @@ export class ItStandardsComponent implements OnInit {
 
       if(daysExpiring > 0) {
         const now = new Date(); // Current date and time
-        now.setUTCHours(0, 0, 0, 0);
+        now.setHours(0, 0, 0, 0);
         const expiringWithin = new Date();
         expiringWithin.setDate(now.getDate() + daysExpiring); // number of days set in the url
-        expiringWithin.setUTCHours(0, 0, 0, 0);
+        expiringWithin.setHours(0, 0, 0, 0);
         const expiringFiltered: ITStandards[] = [];
         i.forEach(x => {
           let renewal = new Date(x.ApprovalExpirationDate);
-          renewal.setUTCHours(0, 0, 0, 0);
+          renewal.setHours(0, 0, 0, 0);
           const isInWindow = includePastDue
             ? renewal <= expiringWithin
             : (renewal >= now && renewal <= expiringWithin);
@@ -409,11 +409,11 @@ export class ItStandardsComponent implements OnInit {
         this.tableService.updateReportTableDataReadyStatus(true);
       } else if (pastDueOnly) {
         const now = new Date();
-        now.setUTCHours(0, 0, 0, 0);
+        now.setHours(0, 0, 0, 0);
         const pastDueFiltered: ITStandards[] = [];
         i.forEach(x => {
           let renewal = new Date(x.ApprovalExpirationDate);
-          renewal.setUTCHours(0, 0, 0, 0);
+          renewal.setHours(0, 0, 0, 0);
           if (x.ApprovalExpirationDate && renewal < now && this.isInExpiringStatusScope(x)) {
             pastDueFiltered.push(x);
           }
@@ -422,14 +422,14 @@ export class ItStandardsComponent implements OnInit {
         this.tableService.updateReportTableDataReadyStatus(true);
       } else if(daysRetired > 0) {
         const now = new Date(); // Current date and time
-        now.setUTCHours(0, 0, 0, 0);
+        now.setHours(0, 0, 0, 0);
         const expiredWithin = new Date();
         expiredWithin.setDate(now.getDate() - daysRetired); // number of days set in the url
-        expiredWithin.setUTCHours(0, 0, 0, 0);
+        expiredWithin.setHours(0, 0, 0, 0);
         const expiringFiltered: ITStandards[] = [];
         i.forEach(x => {
           let renewal = new Date(x.ApprovalExpirationDate);
-          renewal.setUTCHours(0, 0, 0, 0);
+          renewal.setHours(0, 0, 0, 0);
           if(x.ApprovalExpirationDate && (renewal <= now && renewal >= expiredWithin) && (x.Status === 'Retired')) {
             expiringFiltered.push(x);
           }
@@ -544,6 +544,12 @@ export class ItStandardsComponent implements OnInit {
 
   // Keep dashboard deep-link filters consistent with backend totals query scope.
   private isInExpiringStatusScope(standard: ITStandards): boolean {
+    const approvedLikeStatusIds = [11, 2, 6, 9];
+
+    if (typeof standard.StatusId === 'number') {
+      return approvedLikeStatusIds.includes(standard.StatusId);
+    }
+
     return standard.Status === 'Approved'
       || standard.Status === 'Approved with conditions'
       || standard.Status === 'Pilot'


### PR DESCRIPTION
…s alerts.

Ticket:
https://github.com/GSA/GEAR3/issues/1031

Rootcause:
The dashboard warning text for FISMA and IT Standards was driven only by the “expiring within 7 days” count.
Records with expiration dates already in the past were excluded by the existing query window (date≥today), so the UI could incorrectly show “No items expiring within 7 days” even when overdue items existed.
Click-through filters from the tiles also only pulled the 7-day future window, so overdue records were hidden there too.

Fix:
Added dedicated past-due totals on the API side for both FISMA and IT Standards.
Updated dashboard tile logic to use combined alert context:
upcoming in 7 days
past due
Replaced the old single-condition message with a combined message builder
Updated tile navigation to pass an includePastDue flag.
Updated FISMA and IT Standards list filtering to honor that flag and include overdue items in the resulting list.

Build:
<img width="796" height="218" alt="image" src="https://github.com/user-attachments/assets/baed378f-d4b2-4ea8-ae18-1d62433c7f94" />
