### PR TITLE
fix: sidebar add EA Team external link to active Enterprise Architect…

### DIFF
--- a/src/app/components/sidebar-v2/sidebar-v2.component.ts
+++ b/src/app/components/sidebar-v2/sidebar-v2.component.ts
@@ -47,6 +47,7 @@ export class SidebarV2Component {
     { text: 'IT Standards Approval Process', href: 'https://sites.google.com/a/gsa.gov/it_standards/software-approvals#h.vioogtbleinq', icon: 'fas fa-external-link-alt' }
   ];
   public enterpriseArchitectureChildren: SidebarButtonChild[] = [
+    { text: 'EA Team', href: 'https://sites.google.com/gsa.gov/enterprisearchitecture/about-us', icon: 'fas fa-external-link-alt' },
     { text: 'GEAR Model Diagram', route: '/gear_model' }
   ];
   public additionalInfoChildren: SidebarButtonChild[] = [

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -129,6 +129,13 @@
           <i class="fas fa-network-wired fa-lg fa-fw"></i>
         </ng-template> -->
         <ng-template pTemplate="content">
+          <a
+            class="sidebar-sublink"
+            (click)="onClickNavigate($event, 'ea_team')"
+            (keydown)="onKeyboardNavigate($event, 'ea_team', false)"
+            href="https://sites.google.com/gsa.gov/enterprisearchitecture/about-us"
+            target="_blank"
+            rel="noopener">EA Team <i class="fas fa-external-link-alt"></i></a>
           <a class="sidebar-sublink" routerLink="/gear_model" (click)="onClickNavigate($event, '/gear_model')" (keydown)="onKeyboardNavigate($event, '/gear_model')">GEAR Model Diagram</a>
         </ng-template>
       </p-accordion-panel>

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -297,6 +297,15 @@
           >
           We need to update the EA view to be more readable before publishing--> 
           <a
+            href="https://sites.google.com/gsa.gov/enterprisearchitecture/about-us"
+            target="_blank"
+            rel="noopener"
+            class="bg-dark list-group-item list-group-item-action"
+          >
+            EA Team
+            <i class="fas fa-external-link-alt"></i
+          ></a>
+          <a
             routerLink="/gear_model"
             class="bg-dark list-group-item list-group-item-action"
           >


### PR DESCRIPTION
…ure sidenav before GEAR Model Diagram.

Ticket:
https://github.com/GSA/GEAR3/issues/1060

Issue:
The first change was applied to legacy sidenav markup, but the UI in your screenshot is rendered by sidebar-v2.component.ts, so the new link did not appear.

Fix: 
Added EA Team external link before GEAR Model Diagram in the active Enterprise Architecture menu list in sidebar-v2.component.ts (and mirrored in legacy sidebar for consistency).

Build:
<img width="1016" height="251" alt="image" src="https://github.com/user-attachments/assets/2c4255b6-50e8-4e12-be33-1df6f3f4cdd6" />
