### PR TITLE
perf: improve Lighthouse performance (caching, compression, static as…

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "bootstrap-datepicker": "^1.9.0",
     "bootstrap-icons": "^1.11.3",
     "bootstrap-table": "^1.24.0",
+    "compression": "^1.8.1",
     "cors": "^2.8.5",
     "d3": "^7.9.0",
     "d3-color": "^3.1.0",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 var dotenv = require('dotenv').config();  // .env Credentials
 
 const bodyParser = require('body-parser'),
+  compression = require('compression'),
   cors = require('cors'),
   express = require('express'),
   fs = require('fs'),
@@ -79,16 +80,37 @@ passport.use(new JWTStrategy({
   }
 ));
 
+const browserBuildPath = path.join(__dirname, 'public', 'browser');
+
+const staticAssetOptions = {
+  etag: true,
+  lastModified: true,
+  setHeaders: (res, servedPath) => {
+    if (servedPath.endsWith('index.html')) {
+      res.setHeader('Cache-Control', 'no-cache');
+      return;
+    }
+
+    const normalizedPath = servedPath.replace(/\\/g, '/');
+    const isFingerprintedAsset = /-(?:[A-Z0-9]{8,})\.(?:js|css)$/.test(normalizedPath);
+
+    if (isFingerprintedAsset) {
+      res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    }
+  }
+};
+
 
 /********************************************************************
 LOAD EXPRESSJS MIDDLEWARE
 ********************************************************************/
 const app = express()
+  .use(compression())
   .use(cors())
   .use(bodyParser.json({ limit: '50mb' }))
   .use(bodyParser.urlencoded({ limit: '50mb', extended: false }))
   .use(passport.initialize())
-  .use(express.static(path.join(__dirname, 'public', 'browser')))
+  .use(express.static(browserBuildPath, staticAssetOptions))
   .enable('trust proxy');  // For expressJS to know we're behind a proxy when deployed
 
 
@@ -412,7 +434,8 @@ app.post(samlConfig.path,
 REDIRECT ROOT TO GEAR "read only" (aka "angular") app
 ********************************************************************/
 app.get('*', function (req, res) {
-  res.sendFile(path.join(__dirname, 'public', 'browser', 'index.html'));
+  res.setHeader('Cache-Control', 'no-cache');
+  res.sendFile(path.join(browserBuildPath, 'index.html'));
 });
 
 /********************************************************************

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,9 @@
     <app-topbar></app-topbar>
     <div class="content-container">
       <app-sidebar-v2></app-sidebar-v2>
-      <router-outlet></router-outlet>
+      <main class="main-content" id="main-content">
+        <router-outlet></router-outlet>
+      </main>
     </div>
   <footer>
     <app-identifier></app-identifier>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -6,6 +6,12 @@
     display: flex;
     flex-direction: row;
     height: 100%;
+
+    & .main-content {
+      display: block;
+      flex: 1 1 auto;
+      min-width: 0;
+    }
   }
 }
 

--- a/src/app/components/banner/banner.component.html
+++ b/src/app/components/banner/banner.component.html
@@ -8,13 +8,13 @@
     @if (isBannerExpanded) {
       <div class="banner-content-container">
         <div class="banner-content-block">
-          <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true" />
+          <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true" loading="lazy" />
           <span><strong>Official websites use .gov</strong><br />A
             <strong>.gov</strong> website belongs to an official government
             organization in the United States.</span>
         </div>
         <div class="banner-content-block">
-          <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true" />
+          <img class="usa-banner__icon usa-media-block__img" src="/assets/img/icon-https.svg" role="img" alt="" aria-hidden="true" loading="lazy" />
           <span><strong>Secure .gov websites use HTTPS</strong><br />A
             <strong>lock</strong> (
             <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64"

--- a/src/app/components/identifier/identifier.component.html
+++ b/src/app/components/identifier/identifier.component.html
@@ -2,8 +2,8 @@
   <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier,">
     <div class="usa-identifier__container">
       <div class="usa-identifier__logos">
-        <a href="">
-        <img src="assets/img/NewGSAlogo.png" width="50" height="44">
+        <a href="https://www.gsa.gov/" target="_blank" rel="noopener" class="usa-link" aria-label="U.S. General Services Administration">
+        <img src="assets/img/NewGSAlogo.png" width="50" height="44" alt="U.S. General Services Administration logo">
         </a>
       </div>
       <section class="usa-identifier__identity" aria-label="Agency description,">

--- a/src/app/components/identifier/identifier.component.html
+++ b/src/app/components/identifier/identifier.component.html
@@ -3,7 +3,7 @@
     <div class="usa-identifier__container">
       <div class="usa-identifier__logos">
         <a href="">
-        <img src="assets/img/NewGSAlogo.png" width="50">
+        <img src="assets/img/NewGSAlogo.png" width="50" height="44">
         </a>
       </div>
       <section class="usa-identifier__identity" aria-label="Agency description,">

--- a/src/app/components/sidebar-button/sidebar-button.component.html
+++ b/src/app/components/sidebar-button/sidebar-button.component.html
@@ -1,4 +1,4 @@
-<div class="sidebar-button" (click)="onButtonClick()" (keyup)="onKeyUp($event)" tabindex="1">
+<div class="sidebar-button" (click)="onButtonClick()" (keyup)="onKeyUp($event)" tabindex="0" [attr.role]="hasChildren() ? 'button' : 'link'" [attr.aria-label]="buttonText" [attr.aria-expanded]="hasChildren() ? isButtonExpanded : null">
   <div class="sidebar-button-icon">
     <i [ngClass]="buttonIcon"></i>
   </div>
@@ -10,7 +10,7 @@
 </div>
 <div class="sidebar-children-container" [ngClass]="{'expanded' : isButtonExpanded}">
   @for (child of buttonChildren; track child) {
-    <div class="sidebar-button-child" (keyup)="onChildKeyUp($event, child)" (click)="onChildButtonClick(child)" tabindex="1">
+    <div class="sidebar-button-child" (keyup)="onChildKeyUp($event, child)" (click)="onChildButtonClick(child)" tabindex="0" role="link" [attr.aria-label]="child.text">
       <div class="sidebar-button-text">
         {{child.text}}
       </div>

--- a/src/app/components/sidebar-button/sidebar-button.component.ts
+++ b/src/app/components/sidebar-button/sidebar-button.component.ts
@@ -69,7 +69,7 @@ export class SidebarButtonComponent implements OnChanges {
         this.routeChange.emit();
     }
 
-    private hasChildren(): boolean {
+    public hasChildren(): boolean {
         return this.buttonChildren && this.buttonChildren.length > 0;
     }
 

--- a/src/app/components/sidebar-v2/sidebar-v2.component.html
+++ b/src/app/components/sidebar-v2/sidebar-v2.component.html
@@ -1,5 +1,5 @@
 <div class="sidebar-container" [ngClass]="{'expanded' : isSidebarExpanded}" (mouseenter)="toggleSidebar()"
-  (mouseleave)="toggleSidebar()" (focus)="toggleSidebar()" tabindex="1" id="sidebar" [class.expanded]="isSidebarExpanded">
+  (mouseleave)="toggleSidebar()" (focus)="toggleSidebar()" tabindex="0" id="sidebar" [class.expanded]="isSidebarExpanded" role="navigation" aria-label="Primary navigation">
   
 <div class="sidebar-button-container">
   <app-sidebar-button buttonText="Dashboard"

--- a/src/app/components/table-v2/table-v2.component.scss
+++ b/src/app/components/table-v2/table-v2.component.scss
@@ -168,8 +168,8 @@
             }
 
             & .table-status-badge-red {
-                background: #FFEFD6;
-                color: #943600;
+                background: #FDE8EA;
+                color: #7A0019;
                 font-size: 0.75rem;
                 font-style: normal;
                 font-weight: 400;
@@ -205,8 +205,8 @@
                 }
 
                 & .table-status-badge-red {
-                    background: #FFEFD6;
-                    color: #943600;
+                    background: #FDE8EA;
+                    color: #7A0019;
                     font-size: 0.75rem;
                     font-style: normal;
                     font-weight: 400;

--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -39,7 +39,7 @@
                   <p-iconField iconPosition="left">
                     <p-inputgroup>
                       <p-inputgroup-addon>
-                        <p-button icon="pi pi-search" severity="secondary" variant="text" (click)="onTableSearchIconClick()" />
+                        <p-button icon="pi pi-search" severity="secondary" variant="text" ariaLabel="Search table" (click)="onTableSearchIconClick()" />
                       </p-inputgroup-addon>
                       <input
                       pInputText

--- a/src/app/components/table/table.component.scss
+++ b/src/app/components/table/table.component.scss
@@ -358,8 +358,8 @@
             }
 
             & .table-status-badge-red {
-                background-color: #FAEAEA;
-                color: #ea0000;
+                background-color: #FDE8EA;
+                color: #7A0019;
                 font-size: 0.75rem;
                 font-style: normal;
                 font-weight: 400;
@@ -411,8 +411,8 @@
                 }
 
                 & .table-status-badge-red {
-                    background-color: #FAEAEA;
-                    color: #ea0000;
+                    background-color: #FDE8EA;
+                    color: #7A0019;
                     font-size: 0.75rem;
                     font-style: normal;
                     font-weight: 400;

--- a/src/app/views/security/fisma/details/fisma-details.component.scss
+++ b/src/app/views/security/fisma/details/fisma-details.component.scss
@@ -93,8 +93,8 @@
                     & .status-red {
                         padding: .5rem;
                         border-radius: 4px;
-                        background-color: #FAEAEA;
-                        color: #9E0000;
+                        background-color: #FDE8EA;
+                        color: #7A0019;
                         display: inline-block;
                     }
 

--- a/src/app/views/systems/systems/details/systems-details.component.scss
+++ b/src/app/views/systems/systems/details/systems-details.component.scss
@@ -136,8 +136,8 @@
                     & .status-red {
                         padding: .5rem;
                         border-radius: 4px;
-                        background-color: #FAEAEA;
-                        color: #9E0000;
+                        background-color: #FDE8EA;
+                        color: #7A0019;
                         display: inline-block;
                     }
 

--- a/src/app/views/systems/websites/details/websites-details.component.html
+++ b/src/app/views/systems/websites/details/websites-details.component.html
@@ -66,13 +66,13 @@
                 </div>
                 @if (hasImages()) {
                   <div class="website-scan-image-container">
-                    <img [src]="getDesktopImg()" [alt]="getDesktopImgAltText()" class="shadow image-one" />
-                    <img [src]="getMobileImg()" [alt]="getMobileImgAltText()" class="shadow image-two" />
+                    <img [src]="getDesktopImg()" [alt]="getDesktopImgAltText()" class="shadow image-one" loading="lazy" />
+                    <img [src]="getMobileImg()" [alt]="getMobileImgAltText()" class="shadow image-two" loading="lazy" />
                   </div>
                 } @else {
                   <div class="website-scan-image-container">
-                    <img src="../../../../../assets/website-screenshots/desktop.png" alt="no desktop screenshot found" class="shadow image-one" />
-                    <img src="../../../../../assets/website-screenshots/mobile.png" alt="no mobile screenshot found" class="shadow image-two" />
+                    <img src="../../../../../assets/website-screenshots/desktop.png" alt="no desktop screenshot found" class="shadow image-one" loading="lazy" />
+                    <img src="../../../../../assets/website-screenshots/mobile.png" alt="no mobile screenshot found" class="shadow image-two" loading="lazy" />
                   </div>
                 }
 

--- a/src/app/views/technologies/details/it-standards-details.component.scss
+++ b/src/app/views/technologies/details/it-standards-details.component.scss
@@ -79,8 +79,8 @@
                     & .status-red {
                         padding: .5rem;
                         border-radius: 4px;
-                        background-color: #FAEAEA;
-                        color: #9E0000;
+                        background-color: #FDE8EA;
+                        color: #7A0019;
                         display: inline-block;
                     }
 

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -22,6 +22,8 @@ import { Column } from '@common/table-classes';
 })
 export class ItStandardsComponent implements OnInit {
 
+  private readonly otherStatuses: string[] = ['Approved', 'Denied', 'Retired'];
+
   // row: Object = <any>{};
   // filteredTable: boolean = false;
   // filterTitle: string = '';
@@ -140,9 +142,17 @@ export class ItStandardsComponent implements OnInit {
   }
 
   private updateTotals(): void {
-    this.apiService.getITStandardsFilterTotals(this.selectedChips).subscribe(t => {
-      this.filterTotals = t;
-    })
+    const filteredData = this.hasSelectedChips()
+      ? this.itStandardsData.filter(standard => this.selectedChips.includes(standard.DeploymentType))
+      : this.itStandardsData;
+
+    this.filterTotals = {
+      ApprovedTotal: filteredData.filter(standard => standard.Status === 'Approved').length,
+      DeniedTotal: filteredData.filter(standard => standard.Status === 'Denied').length,
+      RetiredTotal: filteredData.filter(standard => standard.Status === 'Retired').length,
+      OtherTotal: filteredData.filter(standard => !this.otherStatuses.includes(standard.Status)).length,
+      AllTotal: filteredData.length,
+    };
   }
 
   ngOnInit(): void {
@@ -389,10 +399,12 @@ export class ItStandardsComponent implements OnInit {
     // Set JWT when logged into GEAR Manager when returning from secureAuth
     this.sharedService.setJWTonLogIn();
 
-  this.apiService.getITStandards().subscribe(i => {
-      this.itStandardsData = this.setCondtionStatus(i);
-      this.itStandardsDataTabFilterted = this.setCondtionStatus(i);
-      this.itStandardsDataChipFilterted = this.setCondtionStatus(i);
+    this.apiService.getITStandards().subscribe(i => {
+      const standardsWithConditionStatus = this.setCondtionStatus(i);
+      this.itStandardsData = standardsWithConditionStatus;
+      this.itStandardsDataTabFilterted = standardsWithConditionStatus;
+      this.itStandardsDataChipFilterted = standardsWithConditionStatus;
+      this.updateTotals();
 
       const queryParams = this.route.snapshot.queryParams;
       const daysExpiring = Number(queryParams['expiringWithinDays'] || this.daysExpiring || 0);
@@ -458,10 +470,6 @@ export class ItStandardsComponent implements OnInit {
       if (this.selectedTab !== 'All') {
         this.onSelectTab(this.selectedTab);
       }
-    });
-
-    this.apiService.getITStandardsFilterTotals(this.selectedChips).subscribe(t => {
-      this.filterTotals = t;
     });
 
   //   // Method to open details modal when referenced directly via URL

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/svg+xml" href="/assets/img/cog-solid.svg" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 
 <body>

--- a/web.config
+++ b/web.config
@@ -126,7 +126,8 @@
             <add input="{REQUEST_URI}" pattern="^.*saxt(.*)" negate="true"/>
             <add input="{REQUEST_URI}" pattern="^.*saxtwebservice(.*)" negate="true"/>
           </conditions>
-          <action type="Rewrite" url="public{REQUEST_URI}"/>
+          <!-- Angular CLI outputs to public/browser, not public directly; must match server.js's express.static path -->
+          <action type="Rewrite" url="public/browser{REQUEST_URI}"/>
           <match url=".*"/>
         </rule>
         <rule name="DynamicContent">
@@ -201,13 +202,33 @@
     <!-- To browse web app root directory during debugging, set the value below to true. Set to false before deployment to avoid disclosing web app folder information. -->
 
     <directoryBrowse enabled="false"/>
+    <!-- Static assets are now served natively by IIS (see StaticContent rewrite rule); enable gzip so they aren't sent uncompressed -->
+    <urlCompression doStaticCompression="true" doDynamicCompression="false"/>
     <staticContent>
       <remove fileExtension=".woff"/>
       <!-- In case IIS already has this mime type -->
       <mimeMap fileExtension=".woff" mimeType="application/x-font-woff"/>
+      <remove fileExtension=".woff2"/>
+      <mimeMap fileExtension=".woff2" mimeType="font/woff2"/>
       <clientCache cacheControlMode="DisableCache"/>
     </staticContent>
   </system.webServer>
+
+  <!-- Angular build output is content-hashed, so it can be cached for a year; index.html must stay uncached so deploys take effect immediately -->
+  <location path="public/browser">
+    <system.webServer>
+      <staticContent>
+        <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="365.00:00:00"/>
+      </staticContent>
+    </system.webServer>
+  </location>
+  <location path="public/browser/index.html">
+    <system.webServer>
+      <staticContent>
+        <clientCache cacheControlMode="DisableCache"/>
+      </staticContent>
+    </system.webServer>
+  </location>
 
   <applicationSettings>
     <EABI.Properties.Settings>


### PR DESCRIPTION
…set serving, lazy images).

TIcket:
https://github.com/GSA/GEAR3/issues/1066
https://github.com/GSA/GEAR3/issues/1076

Client-side computation (removed redundant API call)

it-standards.component.ts now computed locally from already-fetched data instead of a second API round-trip; removed the separate getITStandardsFilterTotals() subscribe block entirely.
Server response headers (server.js)

Added compression gzip middleware to the Express pipeline.
Added Cache-Control: public, max-age=31536000, immutable for content-hashed JS/CSS assets.
Added Cache-Control: no-cache for index.html so deploys take effect immediately.
Dependencies (package.json)

Added compression package.
Font loading (index.html)

Removed unused Material Icons Google Fonts <link> (confirmed nothing in the app uses that class).
IIS config (web.config)

Added <location> blocks for browser (1-year cache) and index.html (no-cache).
Fixed a real bug: the StaticContent rewrite rule pointed to public{REQUEST_URI} instead of public/browser{REQUEST_URI} (Angular's actual build output path), which meant every static asset was silently falling through to Node instead of being served natively by IIS.
Enabled <urlCompression doStaticCompression="true"> — needed because static files now bypass Express's gzip middleware once served natively by IIS.
Added a .woff2 MIME type mapping (using the safe remove-then-add pattern) since IIS's native static handler — unlike Node — will 404 on unregistered file extensions, and most of your fonts are .woff2.
Image loading (Lighthouse best practices / CLS)

Added loading="lazy" to the 4 website-screenshot images in websites-details.component.html and the 2 collapsed-banner icons in banner.component.html.
Added height="44" (matching the existing width="50") to the GSA logo in identifier.component.html to prevent layout shift.
Confirmed all target="_blank" links already had rel="noopener" — no change needed.

Build:
<img width="875" height="181" alt="image" src="https://github.com/user-attachments/assets/7331673f-7d1b-4d27-9c8e-ef37ee1fd6a0" />
