### PR TITLE
fix: hide C-SCRM review field and align toolbar button heights with s…

### DIFF
--- a/src/app/common/table-classes.ts
+++ b/src/app/common/table-classes.ts
@@ -5,6 +5,7 @@ export interface Column {
   field: string,
   isSortable?: boolean,
   showColumn?: boolean,
+  hideFromPicker?: boolean,
   class?: string,
   formatter?: Function,
   titleTooltip?: string

--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -53,7 +53,7 @@
                   }
                   @if (showShowHideColumnButton) {
                     <p-multiSelect
-                      [options]="tableCols"
+                      [options]="pickableColumns"
                       [(ngModel)]="visibleColumns"
                       (onChange)="toggleVisible($event)"
                       optionLabel="header"

--- a/src/app/components/table/table.component.scss
+++ b/src/app/components/table/table.component.scss
@@ -457,6 +457,7 @@
         color: #fff;
         background-color: var(--primary-color) !important;
         border-left: 1px solid #fff;
+        height: 38px;
 
         &:hover,
         &:active {
@@ -478,7 +479,7 @@
         background-color: var(--p-primary-color, #027eb2);
         border-color: var(--p-primary-color, #027eb2);
         border-radius: 0;
-        height: 34px;
+        height: 38px;
 
         &:hover {
             background-color: var(--p-primary-hover-color, #1a82ae);

--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -103,6 +103,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
   originalTableData: any[] = [];
 
   visibleColumns: Column[] = [];
+  pickableColumns: Column[] = [];
   exportColumns!: ExportColumn[];
   currentFilterButton: string = '';
   currentFilterButtons: string[] = [];
@@ -270,6 +271,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
   private initializeColumnVisibility() {
     // Simply set visibleColumns to all columns that should be visible
     this.visibleColumns = this.tableCols.filter(col => col.showColumn !== false);
+    this.pickableColumns = this.tableCols.filter(col => !col.hideFromPicker);
   }
 
   public resetVisibleColumns(): void {

--- a/src/app/views/technologies/details/it-standards-details.component.html
+++ b/src/app/views/technologies/details/it-standards-details.component.html
@@ -179,6 +179,7 @@
                     </label>
                     <span>{{detailsData.CriticalReview}}</span>
                   </div>
+                  <!-- C-SCRM Review Results hidden: ServiceNow IT Standards process does not yet support all C-SCRM use cases
                   <div class="data">
                     <label class="data-label">
                       <span [title]="getTooltip('C-SCRM Review Results')" role="tooltip">
@@ -188,6 +189,7 @@
                     </label>
                     <span>{{detailsData.CSCRMReview}}</span>
                   </div>
+                  -->
                 </div>
               </div>
             </div>

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -392,6 +392,7 @@ export class ItStandardsComponent implements OnInit {
         header: 'C-SCRM Review Results',
         isSortable: true,
         showColumn: false,
+        hideFromPicker: true,
         titleTooltip: this.sharedService.getTooltip(this.attrDefinitions, 'C-SCRM Review Results')
       }];
     });

--- a/src/app/views/technologies/manager/it-standards-manager.component.html
+++ b/src/app/views/technologies/manager/it-standards-manager.component.html
@@ -317,6 +317,7 @@
                           }
                         </select>
                       </div>
+                      <!-- C-SCRM Review Results hidden: ServiceNow IT Standards process does not yet support all C-SCRM use cases
                       <div class="data">
                         <label for="itStandCSCRMReview" class="data-label">C-SCRM Review Results</label>
                         <select class="form-control" id="itStandCSCRMReview" formControlName="itStandCSCRMReview">
@@ -326,6 +327,7 @@
                           }
                         </select>
                       </div>
+                      -->
                       @if (is508ExceptionGranted()) {
                         <div class="data">
                           <label for="itStand508ExceptionLink" class="data-label">508 Exception Link<span class="text-danger">*</span></label>


### PR DESCRIPTION
…earch bar.

Ticket:
https://github.com/GSA/GEAR3/issues/1078

Issue:
Search bar overlaps the toolbar buttons due to missing spacing, and button heights are inconsistent with the search bar

Fix:
Hid [CSCRMReview] field from the details view and manager form (kept in DB/codebase)
Set .p-button-primary and .p-multiselect heights to 38px to match the search bar

Build:
<img width="582" height="227" alt="image" src="https://github.com/user-attachments/assets/6a0cf872-5b48-4c27-be28-a74736e4e2f4" />
