### PR TITLE
fix: prevent undefined SQL values and blank dropdown entries

### DIFF
--- a/api/controllers/it-standards.controller.js
+++ b/api/controllers/it-standards.controller.js
@@ -459,6 +459,9 @@ function saveCustomSoftwareRelease(techId, softwareRelease, softwareVersion) {
 
 function updateITStandardRelease(techId, softwareRelease) {
   let queryString = '';
+  if (!softwareRelease || softwareRelease.application === undefined || softwareRelease.application === null) {
+    return queryString;
+  }
   queryString = `UPDATE 
                   obj_technology
                 SET
@@ -520,6 +523,12 @@ function updateData(techId, data) {
   data.itStandConditionsRestrictions = ctrl.setNullEmptyTextHandler(data.itStandConditionsRestrictions);
   data.itStandAlsoKnownAs = ctrl.setNullEmptyTextHandler(data.itStandAlsoKnownAs);
   data.itStand508ExceptionLink = ctrl.setNullEmptyTextHandler(data.itStand508ExceptionLink);
+  if (data.itStandCSCRMReview === undefined || data.itStandCSCRMReview === null || data.itStandCSCRMReview === '') {
+    data.itStandCSCRMReview = null;
+  }
+  if (data.itStandCriticalReview === undefined || data.itStandCriticalReview === null || data.itStandCriticalReview === '') {
+    data.itStandCriticalReview = null;
+  }
 
   data.tcEndOfLifeDate = ctrl.setNullEmptyTextHandler(data.tcEndOfLifeDate);
 
@@ -577,6 +586,12 @@ function saveData(data) {
   data.itStandConditionsRestrictions = ctrl.setNullEmptyTextHandler(data.itStandConditionsRestrictions);
   data.itStandAlsoKnownAs = ctrl.setNullEmptyTextHandler(data.itStandAlsoKnownAs);
   data.itStand508ExceptionLink = ctrl.setNullEmptyTextHandler(data.itStand508ExceptionLink);
+  if (data.itStandCSCRMReview === undefined || data.itStandCSCRMReview === null || data.itStandCSCRMReview === '') {
+    data.itStandCSCRMReview = null;
+  }
+  if (data.itStandCriticalReview === undefined || data.itStandCriticalReview === null || data.itStandCriticalReview === '') {
+    data.itStandCriticalReview = null;
+  }
 
   return `INSERT INTO obj_technology(
             obj_technology_status_Id,

--- a/src/app/views/technologies/manager/it-standards-manager.component.ts
+++ b/src/app/views/technologies/manager/it-standards-manager.component.ts
@@ -333,8 +333,11 @@ export class ItStandardsManagerComponent implements OnInit {
       if (this.itStandard.POC) {
         this.itStandard.POC.split('; ').forEach(poc => {
           // Index 0 has name of POC
-          let pocName = poc.split(', ')[0]
-          pocIDs.push(this.sharedService.findInArray(this.POCs, 'Name', pocName, 'SamAccountName'));
+          let pocName = poc.split(', ')[0];
+          const samAccountName = this.sharedService.findInArray(this.POCs, 'Name', pocName, 'SamAccountName');
+          if (samAccountName !== undefined && samAccountName !== null) {
+            pocIDs.push(samAccountName);
+          }
         });
       };
 
@@ -372,7 +375,10 @@ export class ItStandardsManagerComponent implements OnInit {
       if (this.itStandard.Category) {
         this.itStandard.Category.split(', ').forEach(cat => {
           if(cat) {
-            categoryIDs.push(this.sharedService.findInArray(this.categories, 'Name', cat, 'Id'));
+            const catId = this.sharedService.findInArray(this.categories, 'Name', cat, 'Id');
+            if(catId !== undefined && catId !== null) {
+              categoryIDs.push(catId);
+            }
           }
         });
       };
@@ -621,7 +627,12 @@ export class ItStandardsManagerComponent implements OnInit {
       let initialOS: number[] = [];
       if(this.itStandard.OperatingSystems) {
         let initialOSString = this.itStandard.OperatingSystems.split(', ');
-        initialOSString.forEach(o => initialOS.push(this.sharedService.findInArray(this.operatingSystems, 'Name', o)));
+        initialOSString.forEach(o => {
+          const osId = this.sharedService.findInArray(this.operatingSystems, 'Name', o);
+          if (osId !== undefined && osId !== null) {
+            initialOS.push(osId);
+          }
+        });
       }
       this.itStandardsForm.value.initialOS = initialOS;
 


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1080

Issues Fixed:

-undefined SQL error on save — [itStandCSCRMReview] and [itStandCriticalReview] were interpolated directly into SQL when null/undefined, producing ER_BAD_FIELD_ERROR and blocking all saves.

-Blank TRM category entries — [findInArray] returning undefined for unmatched TRM names was pushed into [categoryIDs], rendering empty entries in the Technology Category dropdown.

-Missing TRM category — A category whose name didn't match the DB lookup was silently dropped instead of being filtered cleanly.

-Blank POC entries — Same [findInArray] undefined issue in [pocIDs] population.

-Blank OS entries — Same issue in [initialOS] population.

-[updateITStandardRelease] crash — Calling [.application] on a null/undefined [softwareRelease]caused a TypeError that crashed the save request.

Build:
<img width="729" height="243" alt="image" src="https://github.com/user-attachments/assets/ce35fbe5-a20a-42e7-bb62-9f8ea380a091" />
