### PR TITLE
fix: restore model search on browser back arrow by reading term from …

### DIFF
--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
+import { PreviousRouteService } from '@services/previous-route/previous-route.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
 import { Title } from '@angular/platform-browser';
@@ -51,6 +52,14 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
 
   public searchKey: string = '';
   private finalSearchPath: any = null;
+  private pendingSearchKey: string | null = null;
+
+  private getSearchTermFromHistory(): string | null {
+    const prevUrl = this.previousRouteService.getPreviousEntry()?.url ?? null;
+    if (!prevUrl) return null;
+    const qs = prevUrl.split('?')[1] ?? '';
+    return new URLSearchParams(qs).get('tableSearchTerm');
+  }
 
   constructor(
     private apiService: ApiService,
@@ -60,6 +69,7 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
     private tableService: TableService,
     private titleService: Title,
     private elementRef: ElementRef,
+    private previousRouteService: PreviousRouteService,
     private router: Router
   ) {}
 
@@ -71,6 +81,15 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
 
     // Set JWT when logged into GEAR Manager when returning from secureAuth
     this.sharedService.setJWTonLogIn();
+
+    // Restore search term when returning via breadcrumb or browser back navigation
+    this.route.queryParams.subscribe((params) => {
+      const term = params['tableSearchTerm'] || this.getSearchTermFromHistory();
+      if (term) {
+        this.searchKey = term;
+        this.pendingSearchKey = term;
+      }
+    });
 
     this.getCapData();
 
@@ -209,6 +228,13 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
       // console.log("CapTree: ", this.capTree);  // Debug
       // Create graph after retrieving data and computing tree
       this.createGraph();
+
+      // Restore pending search if user navigated back with a search term
+      if (this.pendingSearchKey) {
+        this.searchKey = this.pendingSearchKey;
+        this.pendingSearchKey = null;
+        this.search({ key: 'Enter' });
+      }
     });
   } // End of getCapData
 
@@ -438,7 +464,9 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
               .subscribe((data: any) => {
                   // var capData = data[0];
                   // this.tableService.capsTableClick(capData);
-                  this.router.navigate(['capabilities', data.ID]);
+                  const qp: Record<string, any> = { fromPrevious: 'GSA Capabilities Model' };
+                  if (this.searchKey) { qp['tableSearchTerm'] = this.searchKey; }
+                  this.router.navigate(['capabilities', data.ID], { queryParams: qp });
                 }
               )
           }

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
@@ -57,6 +57,8 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
   private getSearchTermFromHistory(): string | null {
     const prevUrl = this.previousRouteService.getPreviousEntry()?.url ?? null;
     if (!prevUrl) return null;
+    const path = prevUrl.split('?')[0];
+    if (!path.startsWith('/capabilities/')) return null;
     const qs = prevUrl.split('?')[1] ?? '';
     return new URLSearchParams(qs).get('tableSearchTerm');
   }

--- a/src/app/views/enterprise/organizations-chart/organizations-chart.component.ts
+++ b/src/app/views/enterprise/organizations-chart/organizations-chart.component.ts
@@ -46,6 +46,8 @@ export class OrganizationsChartComponent implements OnInit {
   private getSearchTermFromHistory(): string | null {
     const prevUrl = this.previousRouteService.getPreviousEntry()?.url ?? null;
     if (!prevUrl) return null;
+    const path = prevUrl.split('?')[0];
+    if (!path.startsWith('/organizations/')) return null;
     const qs = prevUrl.split('?')[1] ?? '';
     return new URLSearchParams(qs).get('tableSearchTerm');
   }

--- a/src/app/views/enterprise/organizations-chart/organizations-chart.component.ts
+++ b/src/app/views/enterprise/organizations-chart/organizations-chart.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
+import { PreviousRouteService } from '@services/previous-route/previous-route.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
 import { Title } from '@angular/platform-browser';
@@ -38,12 +39,21 @@ export class OrganizationsChartComponent implements OnInit {
 
   public searchKey: string;
   private finalSearchPath;
+  private pendingSearchKey: string | null = null;
 
   public defExpanded: boolean = false;
+
+  private getSearchTermFromHistory(): string | null {
+    const prevUrl = this.previousRouteService.getPreviousEntry()?.url ?? null;
+    if (!prevUrl) return null;
+    const qs = prevUrl.split('?')[1] ?? '';
+    return new URLSearchParams(qs).get('tableSearchTerm');
+  }
 
   constructor(
     private apiService: ApiService,
     private modalService: ModalsService,
+    private previousRouteService: PreviousRouteService,
     private route: ActivatedRoute,
     private sharedService: SharedService,
     private tableService: TableService,
@@ -53,6 +63,15 @@ export class OrganizationsChartComponent implements OnInit {
 
   ngOnInit(): void {
     this.getOrgData();
+
+    // Restore search term when returning via breadcrumb or browser back navigation
+    this.route.queryParams.subscribe((params) => {
+      const term = params['tableSearchTerm'] || this.getSearchTermFromHistory();
+      if (term) {
+        this.searchKey = term;
+        this.pendingSearchKey = term;
+      }
+    });
 
     // Method to open details modal when referenced directly via URL
     this.route.params.subscribe((params) => {
@@ -166,6 +185,13 @@ export class OrganizationsChartComponent implements OnInit {
       // console.log("OrgTree: ", this.orgTree);  // Debug
       // Create graph after retrieving data and computing tree
       this.createChart();
+
+      // Restore pending search if user navigated back with a search term
+      if (this.pendingSearchKey) {
+        this.searchKey = this.pendingSearchKey;
+        this.pendingSearchKey = null;
+        this.search({ key: 'Enter' });
+      }
     });
   } // End of getOrgData
 
@@ -401,7 +427,9 @@ export class OrganizationsChartComponent implements OnInit {
                 .getOneOrg(this.selectedOrg.srcElement.__data__.data.identity)
                 .subscribe((data: any) => {
                   // this.tableService.orgsTableClick(data);
-                  this.router.navigate(['organizations', data.ID]);
+                  const qp: Record<string, any> = { fromPrevious: 'GSA Organizations Chart' };
+                  if (this.searchKey) { qp['tableSearchTerm'] = this.searchKey; }
+                  this.router.navigate(['organizations', data.ID], { queryParams: qp });
                 });
             }.bind(this)
           );

--- a/src/app/views/technologies/tech-categories-model/tech-categories-model.component.ts
+++ b/src/app/views/technologies/tech-categories-model/tech-categories-model.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
+import { PreviousRouteService } from '@services/previous-route/previous-route.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
 import { Title } from '@angular/platform-browser';
@@ -51,6 +52,14 @@ export class TechCategoriesModelComponent implements OnInit {
 
   public searchKey: string;
   private finalSearchPath;
+  private pendingSearchKey: string | null = null;
+
+  private getSearchTermFromHistory(): string | null {
+    const prevUrl = this.previousRouteService.getPreviousEntry()?.url ?? null;
+    if (!prevUrl) return null;
+    const qs = prevUrl.split('?')[1] ?? '';
+    return new URLSearchParams(qs).get('tableSearchTerm');
+  }
 
   constructor(
     private apiService: ApiService,
@@ -60,6 +69,7 @@ export class TechCategoriesModelComponent implements OnInit {
     private tableService: TableService,
     private titleService: Title,
     private elementRef: ElementRef,
+    private previousRouteService: PreviousRouteService,
     private router: Router
   ) {}
 
@@ -67,6 +77,15 @@ export class TechCategoriesModelComponent implements OnInit {
     // Enable popovers
     $(function () {
       $('[data-bs-toggle="popover"]').popover();
+    });
+
+    // Restore search term when returning via breadcrumb or browser back navigation
+    this.route.queryParams.subscribe((params) => {
+      const term = params['tableSearchTerm'] || this.getSearchTermFromHistory();
+      if (term) {
+        this.searchKey = term;
+        this.pendingSearchKey = term;
+      }
     });
 
     this.getTRMData();
@@ -160,6 +179,13 @@ export class TechCategoriesModelComponent implements OnInit {
       });
 
       this.createGraph();
+
+      // Restore pending search if user navigated back with a search term
+      if (this.pendingSearchKey) {
+        this.searchKey = this.pendingSearchKey;
+        this.pendingSearchKey = null;
+        this.search({ key: 'Enter' });
+      }
     });
   }
 
@@ -389,7 +415,7 @@ export class TechCategoriesModelComponent implements OnInit {
             //   .subscribe((data: any) => {
             //       // var capData = data[0];
             //       // this.tableService.capsTableClick(capData);
-            this.router.navigate(['tech_categories', this.selectedTRM.identity], { queryParams: { fromPrevious: 'Technology Categories Model' } });
+            this.router.navigate(['tech_categories', this.selectedTRM.identity], { queryParams: { fromPrevious: 'Technology Categories Model', ...(this.searchKey ? { tableSearchTerm: this.searchKey } : {}) } });
             //     }
             //   )
           }

--- a/src/app/views/technologies/tech-categories-model/tech-categories-model.component.ts
+++ b/src/app/views/technologies/tech-categories-model/tech-categories-model.component.ts
@@ -57,6 +57,8 @@ export class TechCategoriesModelComponent implements OnInit {
   private getSearchTermFromHistory(): string | null {
     const prevUrl = this.previousRouteService.getPreviousEntry()?.url ?? null;
     if (!prevUrl) return null;
+    const path = prevUrl.split('?')[0];
+    if (!path.startsWith('/tech_categories/')) return null;
     const qs = prevUrl.split('?')[1] ?? '';
     return new URLSearchParams(qs).get('tableSearchTerm');
   }


### PR DESCRIPTION
…nav history.

Ticket:
https://github.com/GSA/GEAR3/issues/1082

Issue:
When using the browser back arrow (instead of the breadcrumb link) to return to the org chart, TRM, or capabilities model after viewing a detail page, the search state was not restored. The breadcrumb's [onBack()] explicitly appends [?tableSearchTerm=IBC] to the URL, so the model component could read it from query params. But the browser back arrow navigates to the bare model URL (e.g., [/org_chart] with no query params, so nothing was read and the tree remained collapsed with an empty search input.

Fix:
Added [PreviousRouteService] to all three model components and a [getSearchTermFromHistory()] helper that reads [tableSearchTerm] from the stored detail-page URL in navigation history (e.g., [/organizations/IBC?tableSearchTerm=IBC]. The restore logic now uses both sources:
This covers both navigation paths — breadcrumb click (query param) and browser back arrow (history entry).

Build:
<img width="717" height="224" alt="image" src="https://github.com/user-attachments/assets/af62ed29-5403-4ca7-a620-719da80a6a5d" />
