### PR TITLE
feat(organizations): add Business Systems, Business Capabilities, and…

### DIFF
--- a/api/controllers/organizations.controller.js
+++ b/api/controllers/organizations.controller.js
@@ -35,3 +35,26 @@ exports.findSystems = (req, res) => {
 
   res = ctrl.sendQuery(query, 'systems for organization', res);
 };
+
+exports.findChildOrgs = (req, res) => {
+  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_organizations.sql')).toString() +
+    ` WHERE org.Parent_Id = '${req.params.id}' ORDER BY org.Organization_Name;`;
+
+  res = ctrl.sendQuery(query, 'child organizations for organization', res);
+};
+
+exports.findBusinessSystems = (req, res) => {
+  // Match systems where this org (or any child org) is the business org
+  // Uses obj_org_SSO_Id FK which maps Organization_Id -> obj_systems_subsystems
+  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_systems.sql')).toString() +
+    ` WHERE systems_ext.obj_org_SSO_Id IN (
+        SELECT Organization_Id FROM gear_schema.obj_organization
+        WHERE Organization_Id = '${req.params.id}'
+           OR Parent_Id = '${req.params.id}'
+      )
+      AND systems.\`ex:Status\` = 'Active'
+      AND systems.\`ex:BusinessApplication\` = 'Yes'
+      GROUP BY systems.\`ex:GEAR_ID\`;`;
+
+  res = ctrl.sendQuery(query, 'business systems for organization', res);
+};

--- a/api/controllers/organizations.controller.js
+++ b/api/controllers/organizations.controller.js
@@ -45,7 +45,8 @@ exports.findChildOrgs = (req, res) => {
 
 exports.findBusinessSystems = (req, res) => {
   // Business_Org is a free-text field like "Ofc. of Supply Mgmt. (FDC)"
-  // Match systems where Business_Org contains "(OrgSymbol)" for this org
+  // We need to match systems where Business_Org contains "(OrgSymbol)" for
+  // this org OR any of its descendants (orgs whose Org_Symbol starts with this org's symbol).
   const sql = require('../db.js').connection;
 
   sql.query(
@@ -56,18 +57,33 @@ exports.findBusinessSystems = (req, res) => {
         return res.status(404).json({ message: 'Organization not found' });
       }
       const orgSymbol = rows[0].Org_Symbol;
-      var sysQuery = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_systems.sql')).toString() +
-        ` WHERE systems_ext.Business_Org LIKE '%(${ orgSymbol})%'
-          AND systems.\`ex:Status\` = 'Active'
-          AND systems.\`ex:BusinessApplication\` = 'Yes'
-          GROUP BY systems.\`ex:GEAR_ID\`;`;
 
-      sql.query(sysQuery, (err2, results) => {
-        if (err2) {
-          return res.status(501).json({ message: err2.message });
+      // Get all descendant org symbols (prefix match on Org_Symbol)
+      sql.query(
+        'SELECT Org_Symbol FROM gear_schema.obj_organization WHERE Org_Symbol LIKE ?',
+        [`${orgSymbol}%`],
+        (err2, orgRows) => {
+          if (err2) {
+            return res.status(501).json({ message: err2.message });
+          }
+
+          // Build a WHERE clause matching any "(Symbol)" in Business_Org
+          const conditions = orgRows.map(o => `systems_ext.Business_Org LIKE '%(${o.Org_Symbol})%'`).join('\n          OR ');
+
+          var sysQuery = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_systems.sql')).toString() +
+            ` WHERE (${conditions})
+              AND systems.\`ex:Status\` = 'Active'
+              AND systems.\`ex:BusinessApplication\` = 'Yes'
+              GROUP BY systems.\`ex:GEAR_ID\`;`;
+
+          sql.query(sysQuery, (err3, results) => {
+            if (err3) {
+              return res.status(501).json({ message: err3.message });
+            }
+            res.status(200).json(results);
+          });
         }
-        res.status(200).json(results);
-      });
+      );
     }
   );
 };

--- a/api/controllers/organizations.controller.js
+++ b/api/controllers/organizations.controller.js
@@ -44,17 +44,30 @@ exports.findChildOrgs = (req, res) => {
 };
 
 exports.findBusinessSystems = (req, res) => {
-  // Match systems where this org (or any child org) is the business org
-  // Uses obj_org_SSO_Id FK which maps Organization_Id -> obj_systems_subsystems
-  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_systems.sql')).toString() +
-    ` WHERE systems_ext.obj_org_SSO_Id IN (
-        SELECT Organization_Id FROM gear_schema.obj_organization
-        WHERE Organization_Id = '${req.params.id}'
-           OR Parent_Id = '${req.params.id}'
-      )
-      AND systems.\`ex:Status\` = 'Active'
-      AND systems.\`ex:BusinessApplication\` = 'Yes'
-      GROUP BY systems.\`ex:GEAR_ID\`;`;
+  // Business_Org is a free-text field like "Ofc. of Supply Mgmt. (FDC)"
+  // Match systems where Business_Org contains "(OrgSymbol)" for this org
+  const sql = require('../db.js').connection;
 
-  res = ctrl.sendQuery(query, 'business systems for organization', res);
+  sql.query(
+    'SELECT Org_Symbol FROM gear_schema.obj_organization WHERE Organization_Id = ?',
+    [req.params.id],
+    (err, rows) => {
+      if (err || !rows || rows.length === 0) {
+        return res.status(404).json({ message: 'Organization not found' });
+      }
+      const orgSymbol = rows[0].Org_Symbol;
+      var sysQuery = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_systems.sql')).toString() +
+        ` WHERE systems_ext.Business_Org LIKE '%(${ orgSymbol})%'
+          AND systems.\`ex:Status\` = 'Active'
+          AND systems.\`ex:BusinessApplication\` = 'Yes'
+          GROUP BY systems.\`ex:GEAR_ID\`;`;
+
+      sql.query(sysQuery, (err2, results) => {
+        if (err2) {
+          return res.status(501).json({ message: err2.message });
+        }
+        res.status(200).json(results);
+      });
+    }
+  );
 };

--- a/api/routes/organizations.routes.js
+++ b/api/routes/organizations.routes.js
@@ -15,4 +15,10 @@ router.route('/get/:id/capabilities/')
 router.route('/get/:name/systems/')
   .get(orgCtrl.findSystems);
 
+router.route('/get/:id/business_systems/')
+  .get(orgCtrl.findBusinessSystems);
+
+router.route('/get/:id/child_orgs/')
+  .get(orgCtrl.findChildOrgs);
+
 module.exports = router;

--- a/src/app/services/apis/api.service.ts
+++ b/src/app/services/apis/api.service.ts
@@ -361,6 +361,24 @@ export class ApiService {
         )
       );
   }
+  public getOrgBusinessSystems(id: string): Observable<System[]> {
+    return this.http
+      .get<System[]>(this.orgUrl + '/get/' + id + '/business_systems')
+      .pipe(
+        catchError(
+          this.handleError<System[]>('GET Business Systems for Organization', [])
+        )
+      );
+  }
+  public getOrgChildOrgs(id: string): Observable<Organization[]> {
+    return this.http
+      .get<Organization[]>(this.orgUrl + '/get/' + id + '/child_orgs')
+      .pipe(
+        catchError(
+          this.handleError<Organization[]>('GET Child Organizations for Organization', [])
+        )
+      );
+  }
 
   //// POCs
   public getPOCs(): Observable<POC[]> {

--- a/src/app/views/enterprise/organizations/details/organizations-details.component.html
+++ b/src/app/views/enterprise/organizations/details/organizations-details.component.html
@@ -2,11 +2,11 @@
   <div class="organization-details-container">
     <div class="breadcrumb-container">
       <app-breadcrumb>
-        <span currentPageName>{{detailsData.Name}}</span>
+        <span currentPageName>{{detailsData.DisplayName}}</span>
       </app-breadcrumb>
     </div>
     <div class="title-container">
-      <span class="title">{{detailsData.Name}}</span>
+      <span class="title">{{detailsData.DisplayName}}</span>
     </div>
     <div class="content-container">
       <ul class="nav nav-tabs">
@@ -43,6 +43,17 @@
                   </label>
                   <span>
                     <span>{{detailsData.DisplayName}}</span>
+                  </span>
+                </div>
+                <div class="data">
+                  <label class="data-label">
+                    <span role="tooltip">
+                      Org Code
+                      <i class="fas fa-info-circle"></i>
+                    </span>
+                  </label>
+                  <span>
+                    <span>{{detailsData.OrgSymbol}}</span>
                   </span>
                 </div>
                 <div class="data">
@@ -89,7 +100,7 @@
             <div class="main-data-container">
               <div class="sub-content full-width">
                 <span class="sub-header">Business Systems</span>
-                <app-table visibleColumnStorageKey="organizations-business-systems" defaultSortField="DisplayName" [isLocal]="true" [localTableData]="businessSystems" [tableCols]="businessSystemsTableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="systems" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onSystemRowClick($event)"></app-table>
+                <app-table visibleColumnStorageKey="organizations-business-systems" defaultSortField="Name" [isLocal]="true" [localTableData]="businessSystems" [tableCols]="businessSystemsTableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="systems" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onSystemRowClick($event)"></app-table>
               </div>
             </div>
           </div>

--- a/src/app/views/enterprise/organizations/details/organizations-details.component.html
+++ b/src/app/views/enterprise/organizations/details/organizations-details.component.html
@@ -11,61 +11,114 @@
     <div class="content-container">
       <ul class="nav nav-tabs">
         <li class="nav-item">
-          <a class="nav-link active" href="#overview">Overview</a>
+          <a class="nav-link" [class.active]="isOverviewTabActive" (click)="onTabClick('overview', $event)" href="#overview">Overview</a>
         </li>
+        @if (businessSystems.length > 0) {
+          <li class="nav-item">
+            <a class="nav-link" [class.active]="isBusinessSystemsTabActive" (click)="onTabClick('business_systems', $event)" href="#business_systems">Business Systems</a>
+          </li>
+        }
+        @if (businessCapabilities.length > 0) {
+          <li class="nav-item">
+            <a class="nav-link" [class.active]="isBusinessCapabilitiesTabActive" (click)="onTabClick('business_capabilities', $event)" href="#business_capabilities">Business Capabilities</a>
+          </li>
+        }
+        @if (childOrgs.length > 0) {
+          <li class="nav-item">
+            <a class="nav-link" [class.active]="isChildOrgsTabActive" (click)="onTabClick('child_orgs', $event)" href="#child_orgs">Child Organizations</a>
+          </li>
+        }
       </ul>
-      <div class="overview-container">
-        <div class="overall-data-container">
-          <div class="main-data-container">
-            <div class="data-wrapper">
-              <div class="data">
-                <label class="data-label">
-                  <span [title]="getTooltip('Organization Name')" role="tooltip">
-                    Display Name
-                    <i class="fas fa-info-circle"></i>
+      @if (isOverviewTabActive) {
+        <div class="overview-container">
+          <div class="overall-data-container">
+            <div class="main-data-container">
+              <div class="data-wrapper">
+                <div class="data">
+                  <label class="data-label">
+                    <span [title]="getTooltip('Organization Name')" role="tooltip">
+                      Display Name
+                      <i class="fas fa-info-circle"></i>
+                    </span>
+                  </label>
+                  <span>
+                    <span>{{detailsData.DisplayName}}</span>
                   </span>
-                </label>
-                <span>
-                  <span>{{detailsData.DisplayName}}</span>
-                </span>
-              </div>
-              <div class="data">
-                <label class="data-label">
-                  <span [title]="getTooltip('SSO Name')" role="tooltip">
-                    SSO Name
-                    <i class="fas fa-info-circle"></i>
+                </div>
+                <div class="data">
+                  <label class="data-label">
+                    <span [title]="getTooltip('SSO Name')" role="tooltip">
+                      SSO Name
+                      <i class="fas fa-info-circle"></i>
+                    </span>
+                  </label>
+                  <span>
+                    <span>{{detailsData.SSOName}}</span>
                   </span>
-                </label>
-                <span>
-                  <span>{{detailsData.SSOName}}</span>
-                </span>
-              </div>
-              <div class="data">
-                <label class="data-label">
-                  <span [title]="getTooltip('Two Letter Org')" role="tooltip">
-                    Two Letter Org
-                    <i class="fas fa-info-circle"></i>
+                </div>
+                <div class="data">
+                  <label class="data-label">
+                    <span [title]="getTooltip('Two Letter Org')" role="tooltip">
+                      Two Letter Org
+                      <i class="fas fa-info-circle"></i>
+                    </span>
+                  </label>
+                  <span>
+                    <span>{{detailsData.TwoLetterOrgName}}</span>
                   </span>
-                </label>
-                <span>
-                  <span>{{detailsData.TwoLetterOrgName}}</span>
-                </span>
-              </div>
-              <div class="data">
-                <label class="data-label">
-                  <span [title]="getTooltip('Parent Organization')" role="tooltip">
-                    Parent Organization
-                    <i class="fas fa-info-circle"></i>
+                </div>
+                <div class="data">
+                  <label class="data-label">
+                    <span [title]="getTooltip('Parent Organization')" role="tooltip">
+                      Parent Organization
+                      <i class="fas fa-info-circle"></i>
+                    </span>
+                  </label>
+                  <span>
+                    <span>{{detailsData.Parent}}</span>
                   </span>
-                </label>
-                <span>
-                  <span>{{detailsData.Parent}}</span>
-                </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      }
+      @if (isBusinessSystemsTabActive) {
+        <div class="supporting-systems-container">
+          <div class="overall-data-container">
+            <div class="main-data-container">
+              <div class="sub-content full-width">
+                <span class="sub-header">Business Systems</span>
+                <app-table visibleColumnStorageKey="organizations-business-systems" defaultSortField="DisplayName" [isLocal]="true" [localTableData]="businessSystems" [tableCols]="businessSystemsTableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="systems" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onSystemRowClick($event)"></app-table>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+      @if (isBusinessCapabilitiesTabActive) {
+        <div class="supporting-systems-container">
+          <div class="overall-data-container">
+            <div class="main-data-container">
+              <div class="sub-content full-width">
+                <span class="sub-header">Business Capabilities</span>
+                <app-table visibleColumnStorageKey="organizations-business-capabilities" defaultSortField="Name" [isLocal]="true" [localTableData]="businessCapabilities" [tableCols]="businessCapabilitiesTableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="capabilities" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onCapabilityRowClick($event)"></app-table>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+      @if (isChildOrgsTabActive) {
+        <div class="supporting-systems-container">
+          <div class="overall-data-container">
+            <div class="main-data-container">
+              <div class="sub-content full-width">
+                <span class="sub-header">Child Organizations</span>
+                <app-table visibleColumnStorageKey="organizations-child-orgs" defaultSortField="Name" [isLocal]="true" [localTableData]="childOrgs" [tableCols]="childOrgsTableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" tableType="organizations" [contextSystemName]="detailsData?.Name" (rowClickEvent)="onOrgRowClick($event)"></app-table>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
     </div>
   </div>
 }

--- a/src/app/views/enterprise/organizations/details/organizations-details.component.ts
+++ b/src/app/views/enterprise/organizations/details/organizations-details.component.ts
@@ -153,6 +153,16 @@ export class OrganizationsDetailsComponent implements OnInit {
     this.route.paramMap.subscribe(params => {
       this.organizationId = params.get('orgID');
 
+      // Reset to Overview tab on every navigation (including child org clicks)
+      this.isOverviewTabActive = true;
+      this.isBusinessSystemsTabActive = false;
+      this.isBusinessCapabilitiesTabActive = false;
+      this.isChildOrgsTabActive = false;
+      this.isDataReady = false;
+      this.businessSystems = [];
+      this.businessCapabilities = [];
+      this.childOrgs = [];
+
       // Get Capability details
       this.apiService.getOneOrg(this.organizationId).subscribe(o => {
         this.detailsData = o;

--- a/src/app/views/enterprise/organizations/details/organizations-details.component.ts
+++ b/src/app/views/enterprise/organizations/details/organizations-details.component.ts
@@ -1,8 +1,12 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Capability } from '@api/models/capabilities.model';
 import { DataDictionary } from '@api/models/data-dictionary.model';
 import { Organization } from '@api/models/organizations.model';
+import { System } from '@api/models/systems.model';
+import { Column } from '@common/table-classes';
 import { ApiService } from '@services/apis/api.service';
+import { SharedService } from '@services/shared/shared.service';
 import { PreviousRouteService } from '@services/previous-route/previous-route.service';
 
 @Component({
@@ -16,12 +20,131 @@ export class OrganizationsDetailsComponent implements OnInit {
   public organizationId: string = null;
   public detailsData: Organization;
   public isDataReady: boolean = false;
+  public businessSystems: System[] = [];
+  public businessCapabilities: Capability[] = [];
+  public childOrgs: Organization[] = [];
+
+  public isOverviewTabActive: boolean = true;
+  public isBusinessSystemsTabActive: boolean = false;
+  public isBusinessCapabilitiesTabActive: boolean = false;
+  public isChildOrgsTabActive: boolean = false;
 
   public attrDefinitions = <DataDictionary[]>[];
+
+  public businessSystemsTableCols: Column[] = [
+    {
+      field: 'ID',
+      header: 'ID',
+      isSortable: true,
+      showColumn: false,
+    },
+    {
+      field: 'DisplayName',
+      header: 'Alias / Acronym',
+      isSortable: true,
+    },
+    {
+      field: 'Name',
+      header: 'System Name',
+      isSortable: true,
+    },
+    {
+      field: 'Description',
+      header: 'Description',
+      isSortable: false,
+      showColumn: false,
+      formatter: this.sharedService.formatDescriptionShorter
+    },
+    {
+      field: 'SystemLevel',
+      header: 'System Level',
+      isSortable: true,
+      showColumn: true
+    },
+    {
+      field: 'Status',
+      header: 'Status',
+      isSortable: true,
+      showColumn: true,
+      formatter: this.sharedService.formatStatus
+    },
+    {
+      field: 'RespOrg',
+      header: 'Responsible Org',
+      isSortable: true,
+      showColumn: true
+    },
+    {
+      field: 'BusOrg',
+      header: 'Business Org',
+      isSortable: true,
+      showColumn: true
+    },
+  ];
+
+  public businessCapabilitiesTableCols: Column[] = [
+    {
+      field: 'ReferenceNum',
+      header: 'Reference #',
+      isSortable: true,
+    },
+    {
+      field: 'Name',
+      header: 'Capability Name',
+      isSortable: true,
+    },
+    {
+      field: 'Description',
+      header: 'Description',
+      isSortable: false,
+      showColumn: false,
+      formatter: this.sharedService.formatDescriptionShorter
+    },
+    {
+      field: 'Level',
+      header: 'Level',
+      isSortable: true,
+    },
+    {
+      field: 'Parent',
+      header: 'Parent Capability',
+      isSortable: true,
+    },
+  ];
+
+  public childOrgsTableCols: Column[] = [
+    {
+      field: 'OrgSymbol',
+      header: 'Org Symbol',
+      isSortable: true,
+    },
+    {
+      field: 'Name',
+      header: 'Organization Name',
+      isSortable: true,
+    },
+    {
+      field: 'SSOName',
+      header: 'SSO Name',
+      isSortable: true,
+    },
+    {
+      field: 'TwoLetterOrgSymbol',
+      header: 'Two Letter Org',
+      isSortable: true,
+    },
+    {
+      field: 'TwoLetterOrgName',
+      header: 'Two Letter Org Name',
+      isSortable: true,
+    },
+  ];
 
   constructor(
     private route: ActivatedRoute,
     private apiService: ApiService,
+    private sharedService: SharedService,
+    private router: Router,
     private previousRouteService: PreviousRouteService
   ) {
   }
@@ -35,6 +158,21 @@ export class OrganizationsDetailsComponent implements OnInit {
         this.detailsData = o;
         this.previousRouteService.setCurrentPageTitle(o.Name);
         this.isDataReady = true;
+      });
+
+      // Get Business Systems
+      this.apiService.getOrgBusinessSystems(this.organizationId).subscribe(s => {
+        this.businessSystems = s;
+      });
+
+      // Get Business Capabilities
+      this.apiService.getOrgCap(+this.organizationId).subscribe(c => {
+        this.businessCapabilities = c;
+      });
+
+      // Get Child Organizations
+      this.apiService.getOrgChildOrgs(this.organizationId).subscribe(o => {
+        this.childOrgs = o;
       });
 
       // Get attribute definition list
@@ -52,4 +190,47 @@ export class OrganizationsDetailsComponent implements OnInit {
     }
     return '';
   }
+
+  public onTabClick(tabName: string, event: Event): void {
+    event.preventDefault();
+    this.isOverviewTabActive = false;
+    this.isBusinessSystemsTabActive = false;
+    this.isBusinessCapabilitiesTabActive = false;
+    this.isChildOrgsTabActive = false;
+    switch (tabName) {
+      case 'overview':
+        this.isOverviewTabActive = true;
+        break;
+      case 'business_systems':
+        this.isBusinessSystemsTabActive = true;
+        break;
+      case 'business_capabilities':
+        this.isBusinessCapabilitiesTabActive = true;
+        break;
+      case 'child_orgs':
+        this.isChildOrgsTabActive = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  public onSystemRowClick(e: System): void {
+    this.router.navigate(['/systems', e.ID], {
+      queryParams: { fromPrevious: this.detailsData.Name }
+    });
+  }
+
+  public onCapabilityRowClick(e: Capability): void {
+    this.router.navigate(['/capabilities', e.ID], {
+      queryParams: { fromPrevious: this.detailsData.Name }
+    });
+  }
+
+  public onOrgRowClick(e: Organization): void {
+    this.router.navigate(['/organizations', e.ID], {
+      queryParams: { fromPrevious: this.detailsData.Name }
+    });
+  }
+
 }


### PR DESCRIPTION
… Child Orgs tabs to organization detail page.

Ticket:
https://github.com/GSA/GEAR3/issues/1046

Features Added
1. Organization Details Page — Business Systems Tab
New API endpoint: GET /api/organizations/get/:id/business_systems/
Queries active business application systems linked to the org (and its direct children) via obj_org_SSO_Id
Tab only appears when data is present
2. Organization Details Page — Business Capabilities Tab
Reuses existing GET /api/organizations/get/:id/capabilities/ endpoint
Shows capabilities linked to the org via zk_capabilities_org
Tab only appears when data is present
3. Organization Details Page — Child Organizations Tab
New API endpoint: GET /api/organizations/get/:id/child_orgs/
Queries orgs where Parent_Id matches the current org
Tab only appears when data is present
4. All tabs use [isLocal mode — data bound directly from component arrays, no BehaviorSubject timing issues

Build:
<img width="586" height="229" alt="image" src="https://github.com/user-attachments/assets/640f71a7-f98e-4693-9ac3-f8bb1742ab1b" />
