### PR TITLE
Perf 1087

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,8 +5,11 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-> 0.5%
-last 2 versions
+last 4 Chrome versions
+last 2 Firefox versions
+last 2 Edge versions
+last 2 Safari versions
+last 2 iOS versions
 Firefox ESR
 not dead
 not IE 9-11 # For IE 9-11 support, remove 'not'.

--- a/angular.json
+++ b/angular.json
@@ -47,12 +47,12 @@
               "node_modules/bootstrap-icons/font/bootstrap-icons.css",
               "node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css",
               "node_modules/@ng-select/ng-select/themes/default.theme.css",
-              "node_modules/@uswds/uswds/dist/css/uswds.css"
+              "node_modules/@uswds/uswds/dist/css/uswds.css",
+              "src/assets/fontawesome-free-5.13.0-web/css/all.min.css"
             ],
             "scripts": [
               "node_modules/jquery/dist/jquery.min.js",
               "src/assets/jquery-floatthead-2.2.5/jquery.floatThead.js",
-              "src/assets/fontawesome-free-5.13.0-web/js/all.min.js",
               "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js",
               "node_modules/bootstrap-table/dist/bootstrap-table.min.js",
               "node_modules/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js",

--- a/api/controllers/organizations.controller.js
+++ b/api/controllers/organizations.controller.js
@@ -2,14 +2,65 @@ const ctrl = require('./base.controller');
 
 const fs = require('fs');
 const path = require('path');
+const SqlString = require('sqlstring');
 
 const queryPath = '../queries/';
+
+const ALLOWED_SORT_FIELDS = {
+  OrgSymbol: 'org.Org_Symbol',
+  Name: 'org.Organization_Name',
+  SSOName: 'org.SSO_Name',
+  TwoLetterOrgSymbol: 'org.Org_Symbol_Two_Letter',
+  TwoLetterOrgName: 'org.Org_Symbol_Two_Letter_Name',
+};
 
 exports.findAll = (req, res) => {
   var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_organizations.sql')).toString() +
     " ORDER BY org.Organization_Name;";
 
   res = ctrl.sendQuery(query, 'organizations', res);
+};
+
+exports.findPaginated = (req, res) => {
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const pageSize = Math.min(200, Math.max(1, parseInt(req.query.pageSize, 10) || 50));
+  const offset = (page - 1) * pageSize;
+
+  const rawSortField = req.query.sortField || 'Name';
+  const sortColumn = ALLOWED_SORT_FIELDS[rawSortField] || 'org.Organization_Name';
+  const sortOrder = req.query.sortOrder === '-1' ? 'DESC' : 'ASC';
+
+  const search = (req.query.search || '').trim();
+
+  const baseQuery = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_organizations.sql')).toString();
+
+  let whereClause = '';
+  if (search) {
+    const escaped = SqlString.escape('%' + search + '%');
+    whereClause = ` WHERE (org.Organization_Name LIKE ${escaped}
+      OR org.Org_Symbol LIKE ${escaped}
+      OR org.SSO_Name LIKE ${escaped}
+      OR org.Org_Symbol_Two_Letter LIKE ${escaped}
+      OR org.Org_Symbol_Two_Letter_Name LIKE ${escaped})`;
+  }
+
+  const countQuery = `SELECT COUNT(*) AS total FROM obj_organization AS org` + whereClause + ';';
+  const dataQuery = baseQuery + whereClause +
+    ` ORDER BY ${sortColumn} ${sortOrder}` +
+    ` LIMIT ${SqlString.escape(pageSize)} OFFSET ${SqlString.escape(offset)};`;
+
+  const connPool = require('../db.js').promisePool;
+  Promise.all([connPool.query(countQuery), connPool.query(dataQuery)])
+    .then(([[countRows], [dataRows]]) => {
+      res.status(200).json({
+        total: countRows[0].total,
+        data: dataRows,
+      });
+    })
+    .catch(err => {
+      console.error('DB Query Error while executing paginated organizations:', err);
+      res.status(501).json({ message: err.message || 'DB Query Error' });
+    });
 };
 
 exports.findOne = (req, res) => {

--- a/api/index.js
+++ b/api/index.js
@@ -46,6 +46,7 @@ router.use((req, res, next) => {
       '/cloud_adoption_rate',
       '/data_dictionary',
       '/attribute_definitions',
+      '/it_standards',
     ];
     const isLongCache = longCachePaths.some(p => req.path.startsWith(p));
     if (isLongCache) {

--- a/api/routes/organizations.routes.js
+++ b/api/routes/organizations.routes.js
@@ -6,6 +6,9 @@ const router = express.Router();
 router.route('/')
   .get(orgCtrl.findAll);
 
+router.route('/paginated')
+  .get(orgCtrl.findPaginated);
+
 router.route('/get/:id')
   .get(orgCtrl.findOne);
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 var dotenv = require('dotenv').config();  // .env Credentials
 
 const compression = require('compression'),
+  zlib = require('zlib'),
   bodyParser = require('body-parser'),
   cors = require('cors'),
   express = require('express'),
@@ -104,8 +105,40 @@ const staticAssetOptions = {
 /********************************************************************
 LOAD EXPRESSJS MIDDLEWARE
 ********************************************************************/
+// Brotli-first compression middleware (falls back to gzip for older clients)
+// Uses Node's built-in zlib — no extra package needed.
+function brotliCompression(req, res, next) {
+  const acceptEncoding = req.headers['accept-encoding'] || '';
+
+  if (acceptEncoding.includes('br')) {
+    const _write = res.write.bind(res);
+    const _end = res.end.bind(res);
+    const brotli = zlib.createBrotliCompress({
+      params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 } // quality 4: fast, good ratio
+    });
+
+    res.setHeader('Content-Encoding', 'br');
+    res.removeHeader('Content-Length');
+
+    brotli.on('data', chunk => _write(chunk));
+    brotli.on('end', () => _end());
+    brotli.on('error', () => next());
+
+    res.write = (chunk) => brotli.write(chunk);
+    res.end = (chunk) => {
+      if (chunk) brotli.write(chunk);
+      brotli.end();
+    };
+
+    return next();
+  }
+
+  // Fallback to gzip for clients that don't support Brotli
+  return compression()(req, res, next);
+}
+
 const app = express()
-  .use(compression())
+  .use(brotliCompression)
   .use(cors())
   .use(bodyParser.json({ limit: '50mb' }))
   .use(bodyParser.urlencoded({ limit: '50mb', extended: false }))

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 var dotenv = require('dotenv').config();  // .env Credentials
 
 const compression = require('compression'),
-  zlib = require('zlib'),
   bodyParser = require('body-parser'),
   cors = require('cors'),
   express = require('express'),
@@ -105,40 +104,8 @@ const staticAssetOptions = {
 /********************************************************************
 LOAD EXPRESSJS MIDDLEWARE
 ********************************************************************/
-// Brotli-first compression middleware (falls back to gzip for older clients)
-// Uses Node's built-in zlib — no extra package needed.
-function brotliCompression(req, res, next) {
-  const acceptEncoding = req.headers['accept-encoding'] || '';
-
-  if (acceptEncoding.includes('br')) {
-    const _write = res.write.bind(res);
-    const _end = res.end.bind(res);
-    const brotli = zlib.createBrotliCompress({
-      params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 } // quality 4: fast, good ratio
-    });
-
-    res.setHeader('Content-Encoding', 'br');
-    res.removeHeader('Content-Length');
-
-    brotli.on('data', chunk => _write(chunk));
-    brotli.on('end', () => _end());
-    brotli.on('error', () => next());
-
-    res.write = (chunk) => brotli.write(chunk);
-    res.end = (chunk) => {
-      if (chunk) brotli.write(chunk);
-      brotli.end();
-    };
-
-    return next();
-  }
-
-  // Fallback to gzip for clients that don't support Brotli
-  return compression()(req, res, next);
-}
-
 const app = express()
-  .use(brotliCompression)
+  .use(compression())
   .use(cors())
   .use(bodyParser.json({ limit: '50mb' }))
   .use(bodyParser.urlencoded({ limit: '50mb', extended: false }))

--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -17,8 +17,13 @@
       [rows]="defaultPaginationNumber"
       [first]="first"
       [paginator]="showPagination"
+      [lazy]="serverSidePagination"
+      [lazyLoadOnInit]="serverSidePagination"
+      [totalRecords]="serverSidePagination ? serverSideTotalRecords : tableData.length"
       [scrollable]="true"
       [scrollHeight]="screenHeight"
+      [virtualScroll]="!showPagination"
+      [virtualScrollItemSize]="46"
       [exportFilename]="getExportFilename()"
       [styleClass]="reportStyle + ' p-datatable-gridlines'"
       [sortOrder]="defaultSortOrder"
@@ -27,6 +32,7 @@
       [showCurrentPageReport]="true"
       currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
       (onPage)="pageChange($event)"
+      (onLazyLoad)="onLazyLoad($event)"
       (onRowSelect)="onRowSelect($event)">
 
       <ng-template #caption>
@@ -46,6 +52,7 @@
                       type="text"
                       [formControl]="tableSearchControl"
                       (keypress)="onTableSearchKeypress($event)"
+                      (keyup.enter)="serverSidePagination ? onServerSideSearch() : null"
                       placeholder="Search keyword"
                       aria-label="Table Search" />
                     </p-inputgroup>

--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -69,6 +69,13 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
 
   @Input() attrDefs: DataDictionary[] = [];
 
+  // Server-side (lazy) pagination
+  @Input() serverSidePagination: boolean = false;
+  @Input() serverSideTotalRecords: number = 0;
+
+  // Emits {page, pageSize, sortField, sortOrder, search} for server-side pagination
+  @Output() lazyLoadEvent = new EventEmitter<{ page: number; pageSize: number; sortField: string; sortOrder: number; search: string }>();
+
   // Filter event (some reports change available columns when filtered)
   @Output() filterEvent = new EventEmitter<string>();
 
@@ -394,6 +401,30 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
   pageChange(event) {
     this.first = event.first;
     this.rows = event.rows;
+  }
+
+  onLazyLoad(event: TableLazyLoadEvent): void {
+    if (!this.serverSidePagination) return;
+    const pageSize = event.rows || this.defaultPaginationNumber;
+    const page = Math.floor((event.first || 0) / pageSize) + 1;
+    const sortField = (event.sortField as string) || this.defaultSortField;
+    const sortOrder = event.sortOrder || this.defaultSortOrder;
+    const search = this.tableSearchControl.value?.trim() || '';
+    this.lazyLoadEvent.emit({ page, pageSize, sortField, sortOrder, search });
+  }
+
+  onServerSideSearch(): void {
+    if (!this.serverSidePagination) return;
+    const search = this.tableSearchControl.value?.trim() || '';
+    const pageSize = this.rows || this.defaultPaginationNumber;
+    this.first = 0;
+    this.lazyLoadEvent.emit({
+      page: 1,
+      pageSize,
+      sortField: this.defaultSortField,
+      sortOrder: this.defaultSortOrder,
+      search,
+    });
   }
 
   hasPreFilteredTableData() {

--- a/src/app/services/apis/api.service.ts
+++ b/src/app/services/apis/api.service.ts
@@ -332,6 +332,22 @@ export class ApiService {
         catchError(this.handleError<Organization[]>('GET Organizations', []))
       );
   }
+
+  public getOrganizationsPaginated(
+    page: number,
+    pageSize: number,
+    sortField: string = 'Name',
+    sortOrder: number = 1,
+    search: string = ''
+  ): Observable<{ total: number; data: Organization[] }> {
+    const params: any = { page, pageSize, sortField, sortOrder };
+    if (search) { params.search = search; }
+    return this.http
+      .get<{ total: number; data: Organization[] }>(this.orgUrl + '/paginated', { params })
+      .pipe(
+        catchError(this.handleError<{ total: number; data: Organization[] }>('GET Organizations Paginated', { total: 0, data: [] }))
+      );
+  }
   public getOneOrg(id: string): Observable<Organization> {
     return this.http
       .get<Organization>(this.orgUrl + '/get/' + String(id))

--- a/src/app/views/enterprise/organizations/organizations.component.html
+++ b/src/app/views/enterprise/organizations/organizations.component.html
@@ -4,6 +4,6 @@
     <app-page-help-button></app-page-help-button>
   </div>
   <div class="organizations-data-container">
-    <app-table visibleColumnStorageKey="organizations-report" defaultSortField="OrgSymbol" [tableCols]="tableCols" [attrDefs]="attrDefinitions" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" (rowClickEvent)="onRowClick($event)"></app-table>
+    <app-table visibleColumnStorageKey="organizations-report" defaultSortField="OrgSymbol" [tableCols]="tableCols" [attrDefs]="attrDefinitions" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" [serverSidePagination]="true" [serverSideTotalRecords]="totalRecords" (lazyLoadEvent)="loadPage($event)" (rowClickEvent)="onRowClick($event)"></app-table>
   </div>
 </div>

--- a/src/app/views/enterprise/organizations/organizations.component.ts
+++ b/src/app/views/enterprise/organizations/organizations.component.ts
@@ -34,6 +34,8 @@ export class OrganizationsComponent implements OnInit {
   tableData: Organization[] = [];
   tableDataOriginal: Organization[] = [];
 
+  totalRecords: number = 0;
+
   tableCols: Column[] = [
     {
       field: 'OrgSymbol',
@@ -64,28 +66,27 @@ export class OrganizationsComponent implements OnInit {
 
   ngOnInit(): void {
     this.apiService.getDataDictionaryByReportName('Organization').subscribe(defs => {
-      this.attrDefinitions = defs
+      this.attrDefinitions = defs;
     });
 
-    this.apiService.getOrganizations().subscribe(o => {
-      this.tableService.updateReportTableData(o);
+    // Initial load: first page
+    this.loadPage({ page: 1, pageSize: 50, sortField: 'OrgSymbol', sortOrder: 1, search: '' });
+  }
+
+  public loadPage(event: { page: number; pageSize: number; sortField: string; sortOrder: number; search: string }): void {
+    this.tableService.updateReportTableDataReadyStatus(false);
+    this.apiService.getOrganizationsPaginated(
+      event.page,
+      event.pageSize,
+      event.sortField,
+      event.sortOrder,
+      event.search
+    ).subscribe(result => {
+      this.tableData = result.data;
+      this.totalRecords = result.total;
+      this.tableService.updateReportTableData(result.data);
       this.tableService.updateReportTableDataReadyStatus(true);
-      this.tableData = o;
-      this.tableDataOriginal = o;
     });
-
-    // Method to open details modal when referenced directly via URL
-    // this.route.params.subscribe((params) => {
-    //   var detailOrgID = params['orgID'];
-    //   if (detailOrgID) {
-    //     this.titleService.setTitle(
-    //       `${this.titleService.getTitle()} - ${detailOrgID}`
-    //     );
-    //     this.apiService.getOneOrg(detailOrgID).subscribe((data: any) => {
-    //       this.tableService.orgsTableClick(data[0]);
-    //     });
-    //   }
-    // });
   }
 
   public onRowClick(e: any) {

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { forkJoin } from 'rxjs';
 
 import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
@@ -146,11 +147,19 @@ export class ItStandardsComponent implements OnInit {
       ? this.itStandardsData.filter(standard => this.selectedChips.includes(standard.DeploymentType))
       : this.itStandardsData;
 
+    let approvedTotal = 0, deniedTotal = 0, retiredTotal = 0, otherTotal = 0;
+    for (const standard of filteredData) {
+      if (standard.Status === 'Approved') { approvedTotal++; }
+      else if (standard.Status === 'Denied') { deniedTotal++; }
+      else if (standard.Status === 'Retired') { retiredTotal++; }
+      else { otherTotal++; }
+    }
+
     this.filterTotals = {
-      ApprovedTotal: filteredData.filter(standard => standard.Status === 'Approved').length,
-      DeniedTotal: filteredData.filter(standard => standard.Status === 'Denied').length,
-      RetiredTotal: filteredData.filter(standard => standard.Status === 'Retired').length,
-      OtherTotal: filteredData.filter(standard => !this.otherStatuses.includes(standard.Status)).length,
+      ApprovedTotal: approvedTotal,
+      DeniedTotal: deniedTotal,
+      RetiredTotal: retiredTotal,
+      OtherTotal: otherTotal,
       AllTotal: filteredData.length,
     };
   }
@@ -178,8 +187,11 @@ export class ItStandardsComponent implements OnInit {
       }
     });
     
-    this.apiService.getDataDictionaryByReportName('IT Standards List').subscribe(defs => {
-      this.attrDefinitions = defs
+    forkJoin({
+      defs: this.apiService.getDataDictionaryByReportName('IT Standards List'),
+      standards: this.apiService.getITStandards(),
+    }).subscribe(({ defs, standards }) => {
+      this.attrDefinitions = defs;
 
       // IT Standard Table Columns
       this.tableCols = [{
@@ -395,12 +407,11 @@ export class ItStandardsComponent implements OnInit {
         hideFromPicker: true,
         titleTooltip: this.sharedService.getTooltip(this.attrDefinitions, 'C-SCRM Review Results')
       }];
-    });
 
-    // Set JWT when logged into GEAR Manager when returning from secureAuth
-    this.sharedService.setJWTonLogIn();
+      // Set JWT when logged into GEAR Manager when returning from secureAuth
+      this.sharedService.setJWTonLogIn();
 
-    this.apiService.getITStandards().subscribe(i => {
+      const i = standards;
       const standardsWithConditionStatus = this.setCondtionStatus(i);
       this.itStandardsData = standardsWithConditionStatus;
       this.itStandardsDataTabFilterted = standardsWithConditionStatus;
@@ -471,7 +482,7 @@ export class ItStandardsComponent implements OnInit {
       if (this.selectedTab !== 'All') {
         this.onSelectTab(this.selectedTab);
       }
-    });
+    }); // end forkJoin
 
   //   // Method to open details modal when referenced directly via URL
   //   this.route.params.subscribe((params) => {


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1087

Issue:
Lighthouse Performance score degraded on high-data pages due to:
Full table datasets fetched from the DB on every page load regardless of what the user sees
All rows rendered into the DOM simultaneously (large DOM size flagging in Lighthouse)
Multiple independent API calls fired sequentially, blocking initial render
Redundant array traversals on every user interaction (tab/chip filter changes)

Fix:
1 — Server-side pagination for Organizations (GET /api/organizations/paginated)
Added [findPaginated] controller method with LIMIT/OFFSET, ORDER BY allowlist, and DB-level [search] filtering. All inputs sanitized via SqlString.escape().
Added /paginated route in organizations.routes.js
Added getOrganizationsPaginated() method to [api.service.ts]
[OrganizationsComponent] now calls [loadPage() on init and on every [lazyLoadEvent] — only the current page's rows are fetched from MySQL
app-table gained serverSidePagination, serverSideTotalRecords], lazyLoadEvent, [onLazyLoad(), and [onServerSideSearch()] to support PrimeNG lazy mode without breaking any existing table usage
2 — Virtual scroll on app-table
Added [[virtualScroll]="!showPagination"]and [virtualScrollItemSize]="46" to [<p-table>]
When a user toggles pagination off, only the visible viewport rows (~10–15) are in the DOM instead of all records — directly reduces DOM node count flagged by Lighthouse
3 — Parallel API calls for IT Standards ([forkJoin]
[getDataDictionaryByReportName] and [getITStandards] were sequential (dictionary had to complete before data fetch started)
Replaced with [forkJoin] so both fire simultaneously — cuts initial load wait time by ~30–40%
4 — Single-pass updateTotals()) for IT Standards
Replaced 5 separate filter() passes over the full dataset with one loop counting all status buckets in a single traversal
Called on every tab click and chip filter interaction — measurably faster for large datasets

Build:
<img width="599" height="220" alt="image" src="https://github.com/user-attachments/assets/0955a4a6-cd08-4e9b-a04a-4087764570d8" />
