### PR TITLE
fix: add tooltip bindings to Points of Contact tab field labels

### DIFF
--- a/src/app/views/security/fisma/details/fisma-details.component.html
+++ b/src/app/views/security/fisma/details/fisma-details.component.html
@@ -245,7 +245,7 @@
       <div class="main-data-container poc-main-data">
         <div class="data">
           <label class="data-label">
-            <span>
+            <span [title]="getTooltip('Authorizing Official')" role="tooltip">
               Authorizing Official
               <i class="fas fa-info-circle"></i>
             </span>
@@ -254,7 +254,7 @@
         </div>
         <div class="data">
           <label class="data-label">
-            <span>
+            <span [title]="getTooltip('System Owner')" role="tooltip">
               System Owner
               <i class="fas fa-info-circle"></i>
             </span>
@@ -263,7 +263,7 @@
         </div>
         <div class="data">
           <label class="data-label">
-            <span>
+            <span [title]="getTooltip('ISSM')" role="tooltip">
               ISSM
               <i class="fas fa-info-circle"></i>
             </span>
@@ -272,7 +272,7 @@
         </div>
         <div class="data">
           <label class="data-label">
-            <span>
+            <span [title]="getTooltip('ISSO')" role="tooltip">
               ISSO
               <i class="fas fa-info-circle"></i>
             </span>
@@ -281,7 +281,7 @@
         </div>
         <div class="data">
           <label class="data-label">
-            <span>
+            <span [title]="getTooltip('Contracting Officer')" role="tooltip">
               Contracting Officer
               <i class="fas fa-info-circle"></i>
             </span>
@@ -290,7 +290,7 @@
         </div>
         <div class="data">
           <label class="data-label">
-            <span>
+            <span [title]="getTooltip('Contracting Officer Representative')" role="tooltip">
               Contracting Officer Representative
               <i class="fas fa-info-circle"></i>
             </span>
@@ -299,7 +299,7 @@
         </div>
         <div class="data">
           <label class="data-label">
-            <span>
+            <span [title]="getTooltip('Business POC')" role="tooltip">
               Business POC
               <i class="fas fa-info-circle"></i>
             </span>
@@ -308,7 +308,7 @@
         </div>
         <div class="data">
           <label class="data-label">
-            <span>
+            <span [title]="getTooltip('Technical POC')" role="tooltip">
               Technical POC
               <i class="fas fa-info-circle"></i>
             </span>


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1089

Issue:

On the FISMA system detail page, hovering over POC field titles (Authorizing Official, System Owner, ISSM, ISSO, Contracting Officer, Contracting Officer Representative, Business POC, Technical POC) on the Points of Contact tab showed no helper text. The <span> elements wrapping each label were missing the [[title]="getTooltip and role="tooltip" attributes that the Overview tab uses to display Data Dictionary definitions on hover.

Fix:
Added [[title]="getTooltip and role="tooltip" to the <span> inside each POC field's <label> in [fisma-details.component.html], matching the existing pattern used on all other tabs of the FISMA detail page.

Build:
<img width="592" height="226" alt="image" src="https://github.com/user-attachments/assets/11c2b9ac-4c5b-479f-8363-872d577d4de3" />
