### PR TITLE
fix: restore correct back route when navigating from chart/model views

### DIFF
--- a/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -68,6 +68,7 @@ export class BreadcrumbComponent implements OnInit {
         const currentParams = new URLSearchParams(this.router.url.split('?')[1] ?? '');
         const fromPrevious = currentParams.get('fromPrevious');
         const onBack = currentParams.get('onBack');
+        const originRoute = currentParams.get('originRoute');
 
         const currentBase = this.route.snapshot.url[0]?.path ?? '';
         const currentMeta = ROUTE_META[currentBase];
@@ -81,6 +82,23 @@ export class BreadcrumbComponent implements OnInit {
             const prevSegments = prevPath.split('/').filter(s => s);
             const prevBase = prevSegments[0] ?? '';
             const prevMeta = ROUTE_META[prevBase];
+
+            // Determine the origin route: prefer the explicit param, then look back at
+            // the prev entry's own URL params, then derive from the prev entry itself if
+            // it was a list/chart page.
+            if (!originRoute) {
+                const prevParams = new URLSearchParams(prevUrl?.split('?')[1] ?? '');
+                const prevOrigin = prevParams.get('originRoute');
+                if (prevOrigin) {
+                    (this as any)._resolvedOriginRoute = prevOrigin;
+                } else if (prevSegments.length === 1) {
+                    (this as any)._resolvedOriginRoute = prevPath;
+                } else {
+                    (this as any)._resolvedOriginRoute = null;
+                }
+            } else {
+                (this as any)._resolvedOriginRoute = originRoute;
+            }
 
             if (prevPath === '/') {
                 this.topLevelName = '';
@@ -98,11 +116,25 @@ export class BreadcrumbComponent implements OnInit {
                 this.previousLevelName = prevEntry.title ?? fromPrevious ?? prevMeta?.listName ?? '';
             }
         } else {
-            // No navigation history (direct URL, page refresh) or user clicked back
-            // Fall back to the parent list for this route
-            this.topLevelName = currentMeta?.section ?? '';
-            this.previousLevelName = fromPrevious ?? currentMeta?.listName ?? '';
-            this.previousRouteWithoutParams = currentMeta?.listRoute ?? `/${currentBase}`;
+            // No navigation history (direct URL, page refresh) or user clicked back.
+            // If an originRoute was passed, use it so the breadcrumb still points to
+            // the chart/model the user originally came from instead of defaulting to
+            // the generic list route.
+            const resolvedOrigin: string | null = originRoute ?? null;
+            if (resolvedOrigin) {
+                const originSegments = resolvedOrigin.split('/').filter(s => s);
+                const originBase = originSegments[0] ?? '';
+                const originMeta = ROUTE_META[originBase];
+                this.topLevelName = currentMeta?.section ?? '';
+                this.previousLevelName = fromPrevious ?? originMeta?.listName ?? currentMeta?.listName ?? '';
+                this.previousRouteWithoutParams = resolvedOrigin;
+            } else {
+                // Fall back to the parent list for this route
+                this.topLevelName = currentMeta?.section ?? '';
+                this.previousLevelName = fromPrevious ?? currentMeta?.listName ?? '';
+                this.previousRouteWithoutParams = currentMeta?.listRoute ?? `/${currentBase}`;
+            }
+            (this as any)._resolvedOriginRoute = resolvedOrigin;
         }
     }
 
@@ -110,6 +142,10 @@ export class BreadcrumbComponent implements OnInit {
         const queryParams: Record<string, any> = { onBack: true };
         if (this.tableSearchTerm) {
             queryParams['tableSearchTerm'] = this.tableSearchTerm;
+        }
+        const resolvedOrigin: string | null = (this as any)._resolvedOriginRoute ?? null;
+        if (resolvedOrigin) {
+            queryParams['originRoute'] = resolvedOrigin;
         }
         this.router.navigate([this.previousRouteWithoutParams], { queryParams });
     }

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
@@ -466,7 +466,7 @@ export class CapabilitiesModelComponent implements OnInit, AfterViewInit {
               .subscribe((data: any) => {
                   // var capData = data[0];
                   // this.tableService.capsTableClick(capData);
-                  const qp: Record<string, any> = { fromPrevious: 'GSA Capabilities Model' };
+                  const qp: Record<string, any> = { fromPrevious: 'GSA Capabilities Model', originRoute: '/capabilities_model' };
                   if (this.searchKey) { qp['tableSearchTerm'] = this.searchKey; }
                   this.router.navigate(['capabilities', data.ID], { queryParams: qp });
                 }

--- a/src/app/views/enterprise/capabilities/details/capabilities-details.component.ts
+++ b/src/app/views/enterprise/capabilities/details/capabilities-details.component.ts
@@ -272,9 +272,13 @@ export class CapabilitiesDetailsComponent implements OnInit {
   }
 
   public onOrgRowClick(e: Organization) {
-    this.router.navigate(['/organizations', e.ID], {
-      queryParams: { fromPrevious: this.detailsData.Name }
-    });
+    const currentParams = new URLSearchParams(this.router.url.split('?')[1] ?? '');
+    const originRoute = currentParams.get('originRoute');
+    const queryParams: Record<string, any> = { fromPrevious: this.detailsData.Name };
+    if (originRoute) {
+      queryParams['originRoute'] = originRoute;
+    }
+    this.router.navigate(['/organizations', e.ID], { queryParams });
   }
 
   public onSystemRowClick(e: System) {

--- a/src/app/views/enterprise/organizations-chart/organizations-chart.component.ts
+++ b/src/app/views/enterprise/organizations-chart/organizations-chart.component.ts
@@ -429,7 +429,7 @@ export class OrganizationsChartComponent implements OnInit {
                 .getOneOrg(this.selectedOrg.srcElement.__data__.data.identity)
                 .subscribe((data: any) => {
                   // this.tableService.orgsTableClick(data);
-                  const qp: Record<string, any> = { fromPrevious: 'GSA Organizations Chart' };
+                  const qp: Record<string, any> = { fromPrevious: 'GSA Organizations Chart', originRoute: '/org_chart' };
                   if (this.searchKey) { qp['tableSearchTerm'] = this.searchKey; }
                   this.router.navigate(['organizations', data.ID], { queryParams: qp });
                 });

--- a/src/app/views/enterprise/organizations/details/organizations-details.component.ts
+++ b/src/app/views/enterprise/organizations/details/organizations-details.component.ts
@@ -238,9 +238,13 @@ export class OrganizationsDetailsComponent implements OnInit {
   }
 
   public onOrgRowClick(e: Organization): void {
-    this.router.navigate(['/organizations', e.ID], {
-      queryParams: { fromPrevious: this.detailsData.Name }
-    });
+    const currentParams = new URLSearchParams(this.router.url.split('?')[1] ?? '');
+    const originRoute = currentParams.get('originRoute');
+    const queryParams: Record<string, any> = { fromPrevious: this.detailsData.Name };
+    if (originRoute) {
+      queryParams['originRoute'] = originRoute;
+    }
+    this.router.navigate(['/organizations', e.ID], { queryParams });
   }
 
 }


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1088

Issue:
When navigating to an organization/capability detail page from the org chart or capabilities model, then drilling into a child record from that detail page, the breadcrumb loses track of the original entry point. Clicking the breadcrumb back link routes to the Organizations List or Capabilities List instead of the Org Chart or Capabilities Model the user came from.

Fix:
Introduced an [originRoute] query parameter that is set when navigating from a chart/model view ([/org_chart] or [/capabilities_model] to a detail page. This parameter is forwarded through subsequent child-record navigations and read by the breadcrumb component to resolve the correct back destination, overriding the default [ROUTE_META] list fallback.

Build:
<img width="708" height="227" alt="image" src="https://github.com/user-attachments/assets/c1f38fe8-c278-46c2-961c-fad5b300bdad" />
