### PR TITLE
fix: bar chart condensed to  left

### DIFF
--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -147,7 +147,6 @@
       </div>
       <div class="bar-chart-content">
         <ngx-charts-bar-vertical
-          [view]="barChartView"
           [scheme]="colorScheme"
           [results]="hostingPlatformsData"
           [gradient]="false"

--- a/src/app/views/dashboard/dashboard.component.scss
+++ b/src/app/views/dashboard/dashboard.component.scss
@@ -252,6 +252,19 @@
         flex: 1 1 100%; /* Full width on small screens */
       }
 
+      & .bar-chart-content {
+        width: 100%;
+
+        ::ng-deep ngx-charts-bar-vertical {
+          display: block;
+          width: 100%;
+
+          ::ng-deep .ngx-charts-outer {
+            width: 100% !important;
+          }
+        }
+      }
+
       & .item-header {
         display: flex;
         flex-direction: row;
@@ -353,6 +366,14 @@
         position: relative;
         display: flex;
         justify-content: center;
+
+        // ngx-charts renders the SVG inside a plain div; we use ::ng-deep to give
+        // that wrapper relative positioning so the center-text overlay is anchored
+        // to the actual chart SVG rather than the full container width.
+        ::ng-deep ngx-charts-pie-chart > div {
+          position: relative;
+        }
+
         & .pie-chart-center-text {
           position: absolute;
           top: 50%;
@@ -361,6 +382,7 @@
           line-height: 0.5;
           transform: translate(-50%, -50%);
           pointer-events: none;
+          z-index: 1;
 
           & .center-title {
             color: #666666;

--- a/src/app/views/dashboard/dashboard.component.scss
+++ b/src/app/views/dashboard/dashboard.component.scss
@@ -351,6 +351,8 @@
 
       & .pie-chart-content {
         position: relative;
+        display: flex;
+        justify-content: center;
         & .pie-chart-center-text {
           position: absolute;
           top: 50%;
@@ -358,6 +360,7 @@
           text-align: center;
           line-height: 0.5;
           transform: translate(-50%, -50%);
+          pointer-events: none;
 
           & .center-title {
             color: #666666;

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -198,9 +198,13 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public ngAfterViewInit(): void {
-    this.updateChartViews();
+    // Defer initial measurement so the flex layout has settled and
+    // container offsetWidth returns the correct value.
+    setTimeout(() => {
+      this.updateChartViews();
+      this.cdr.detectChanges();
+    }, 0);
     this.setupResizeObserver();
-    this.cdr.detectChanges();
   }
 
   public ngOnDestroy(): void {

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -236,8 +236,13 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
       }
 
       this.hostingPlatformsData = finalData;
-      this.updateChartViews();
-      this.cdr.detectChanges();
+      // Defer measurement until after Angular has reflowed the DOM with the new data.
+      // Without this, offsetWidth can be 0 or stale on the initial load, causing the
+      // bar chart to render condensed to the left.
+      setTimeout(() => {
+        this.updateChartViews();
+        this.cdr.detectChanges();
+      }, 0);
     });
   }
 
@@ -257,7 +262,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
   private setupResizeObserver(): void {
     if (typeof ResizeObserver !== 'undefined') {
       this.resizeObserver = new ResizeObserver(() => {
-        this.updateChartViews();
+        // Defer to avoid measuring mid-reflow during resize events
+        setTimeout(() => this.updateChartViews(), 0);
       });
 
       const barContainer = document.querySelector('.bar-chart-content');


### PR DESCRIPTION
Ticket:
https://github.com/GSA/GEAR3/issues/1085

Issue:
On initial page load, the dashboard bar chart renders condensed to the left. This is caused by [updateChartViews()] being called synchronously inside the [loadHostingPlatformsData() subscription callback — before Angular has had a chance to reflow the DOM with the new data. As a result, [barContainer.offsetWidth] returns 0 or a stale value, so ngx-charts receives [view]="[0, 320]" and collapses the chart. The same premature measurement happened inside the [ResizeObserver] callback. A secondary issue was the Cloud Adoption pie chart's center text ("Business Systems 239") not being centered, because the ngx-charts SVG was left-aligned inside its container, misaligning the position: absolute overlay.

Fix:
Wrapped [updateChartViews()] + [cdr.detectChanges() in a [setTimeout(..., 0)] inside [loadHostingPlatformsData()] to defer DOM measurement until after Angular's reflow.
Applied the same [setTimeout(..., 0)deferral to the [ResizeObserver] callback.
Added display: flex; justify-content: center to .pie-chart-content in the SCSS so the SVG is centered horizontally, making the absolute-positioned center text land correctly over the donut hole.

Build:
<img width="592" height="222" alt="image" src="https://github.com/user-attachments/assets/db74fe16-7053-4bc5-bb8b-c6e189e37e44" />

