### PR TITLE
IT Standards Table Performance Updates

### DIFF
--- a/api/controllers/it-standards.controller.js
+++ b/api/controllers/it-standards.controller.js
@@ -3,11 +3,28 @@ const ctrl = require('./base.controller');
 const fs = require('fs');
 const path = require('path');
 const { Guid } = require('typescript-guid');
+const SqlString = require('sqlstring');
 
 const queryPath = '../queries/';
 
+// Read once at module load instead of on every request.
+const IT_STANDARDS_BASE_QUERY = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_it-standards.sql')).toString();
+
+// Treats an 'Approved' record with non-empty Conditions_Restrictions as its own
+// status, matching the frontend's setCondtionStatus() display logic.
+const EFFECTIVE_STATUS_EXPR = `CASE WHEN obj_technology_status.Keyname = 'Approved' AND tech.Conditions_Restrictions IS NOT NULL AND tech.Conditions_Restrictions <> '' THEN 'Approved with conditions' ELSE obj_technology_status.Keyname END`;
+
+const ALLOWED_SORT_FIELDS = {
+  Name: 'Name',
+  ManufacturerName: 'ManufacturerName',
+  Description: 'Description',
+  Status: 'Status',
+  DeploymentType: 'DeploymentType',
+  ApprovalExpirationDate: 'ApprovalExpirationDate',
+};
+
 exports.findAll = (req, res) => {
-  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_it-standards.sql')).toString() +
+  var query = IT_STANDARDS_BASE_QUERY +
     ` WHERE obj_standard_type.Keyname LIKE 'Software'
       AND obj_technology_status.Keyname NOT LIKE 'Not yet submitted'
       GROUP BY tech.Id
@@ -16,13 +33,97 @@ exports.findAll = (req, res) => {
   res = ctrl.sendQuery(query, 'IT Standards', res); //removed sendQuery_cowboy reference
 };
 
+exports.findPaginated = (req, res) => {
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const pageSize = Math.min(200, Math.max(1, parseInt(req.query.pageSize, 10) || 50));
+  const offset = (page - 1) * pageSize;
+
+  const rawSortField = req.query.sortField || 'Name';
+  const sortColumn = ALLOWED_SORT_FIELDS[rawSortField] || 'Name';
+  const sortOrder = req.query.sortOrder === '-1' ? 'DESC' : 'ASC';
+
+  const search = (req.query.search || '').trim();
+  const tab = (req.query.tab || 'All').trim();
+  const chips = (req.query.chips || '').split(',').map(c => c.trim()).filter(Boolean);
+  const expiringWithinDays = parseInt(req.query.expiringWithinDays, 10) || 0;
+  const retiredWithinDays = parseInt(req.query.retiredWithinDays, 10) || 0;
+  const pastDueOnly = req.query.pastDueOnly === 'true';
+  const includePastDue = req.query.includePastDue === 'true';
+
+  let whereClause = ` WHERE obj_standard_type.Keyname LIKE 'Software'
+      AND obj_technology_status.Keyname NOT LIKE 'Not yet submitted'`;
+
+  if (tab === 'Other') {
+    whereClause += ` AND (${EFFECTIVE_STATUS_EXPR}) NOT IN ('Approved','Denied','Retired')`;
+  } else if (tab && tab !== 'All') {
+    whereClause += ` AND (${EFFECTIVE_STATUS_EXPR}) = ${SqlString.escape(tab)}`;
+  }
+
+  if (chips.length > 0) {
+    whereClause += ` AND obj_deployment_type.Keyname IN (${chips.map(c => SqlString.escape(c)).join(',')})`;
+  }
+
+  if (search) {
+    const escaped = SqlString.escape('%' + search + '%');
+    whereClause += ` AND (
+      IFNULL(tech.softwareReleaseName, tech.Keyname) LIKE ${escaped}
+      OR tech.manufacturerName LIKE ${escaped}
+      OR tech.Description LIKE ${escaped}
+      OR obj_technology_status.Keyname LIKE ${escaped}
+      OR obj_deployment_type.Keyname LIKE ${escaped}
+    )`;
+  }
+
+  // Matches the frontend's isInExpiringStatusScope() scope for expiring/past-due/retired deep links.
+  const expiringScopeClause = `(${EFFECTIVE_STATUS_EXPR}) IN ('Approved','Approved with conditions','Pilot','Exception','Sunsetting')`;
+  if (expiringWithinDays > 0) {
+    whereClause += ` AND tech.Approved_Status_Expiration_Date IS NOT NULL
+      AND DATE(tech.Approved_Status_Expiration_Date) <= DATE_ADD(CURDATE(), INTERVAL ${expiringWithinDays} DAY)`;
+    if (!includePastDue) {
+      whereClause += ` AND DATE(tech.Approved_Status_Expiration_Date) >= CURDATE()`;
+    }
+    whereClause += ` AND ${expiringScopeClause}`;
+  } else if (pastDueOnly) {
+    whereClause += ` AND tech.Approved_Status_Expiration_Date IS NOT NULL
+      AND DATE(tech.Approved_Status_Expiration_Date) < CURDATE()
+      AND ${expiringScopeClause}`;
+  } else if (retiredWithinDays > 0) {
+    whereClause += ` AND tech.Approved_Status_Expiration_Date IS NOT NULL
+      AND DATE(tech.Approved_Status_Expiration_Date) <= CURDATE()
+      AND DATE(tech.Approved_Status_Expiration_Date) >= DATE_SUB(CURDATE(), INTERVAL ${retiredWithinDays} DAY)
+      AND obj_technology_status.Keyname = 'Retired'`;
+  }
+
+  const countQuery = `SELECT COUNT(*) AS total FROM (
+      ${IT_STANDARDS_BASE_QUERY}${whereClause} GROUP BY tech.Id
+    ) AS counted;`;
+
+  const dataQuery = `${IT_STANDARDS_BASE_QUERY}${whereClause}
+    GROUP BY tech.Id
+    ORDER BY ${sortColumn} ${sortOrder}
+    LIMIT ${pageSize} OFFSET ${offset};`;
+
+  const connPool = require('../db.js').promisePool;
+  Promise.all([connPool.query(countQuery), connPool.query(dataQuery)])
+    .then(([[countRows], [dataRows]]) => {
+      res.status(200).json({
+        total: countRows[0].total,
+        data: dataRows,
+      });
+    })
+    .catch(err => {
+      console.error('DB Query Error while executing paginated IT standards:', err);
+      res.status(501).json({ message: err.message || 'DB Query Error' });
+    });
+};
+
 exports.getStandardsLite = (req, res) => {
   var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_it-standards-lite.sql')).toString();
   res = ctrl.sendQuery(query, 'IT Standards Lite', res);
 };
 
 exports.findAllApproved = (req, res) => {
-  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_it-standards.sql')).toString() +
+  var query = IT_STANDARDS_BASE_QUERY +
     ` WHERE obj_standard_type.Keyname LIKE 'Software'
       AND obj_technology_status.Keyname = 'Approved'
       GROUP BY tech.Id
@@ -32,7 +133,7 @@ exports.findAllApproved = (req, res) => {
 };
 
 exports.findAllNoFilter = (req, res) => {
-  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_it-standards.sql')).toString() +
+  var query = IT_STANDARDS_BASE_QUERY +
     ` WHERE obj_standard_type.Keyname LIKE 'Software'
       GROUP BY tech.Id
       ORDER BY IFNULL(tech.softwareReleaseName, tech.Keyname);`;
@@ -43,7 +144,7 @@ exports.findAllNoFilter = (req, res) => {
 exports.findOne = (req, res) => {
   let id = req.params.id.trim();
   if(/^\d+$/.test(id)) {
-    var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_it-standards.sql')).toString() +
+    var query = IT_STANDARDS_BASE_QUERY +
       ` WHERE tech.Id = ${id};`;
 
     res = ctrl.sendQuery(query, "individual IT Standard", res);
@@ -53,7 +154,7 @@ exports.findOne = (req, res) => {
 };
 
 exports.findLatest = (req, res) => {
-  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_it-standards.sql')).toString() +
+  var query = IT_STANDARDS_BASE_QUERY +
     ` GROUP BY tech.Id
       ORDER BY tech.CreateDTG DESC LIMIT 1;`;
 
@@ -61,12 +162,12 @@ exports.findLatest = (req, res) => {
 };
 
 exports.updatedWithinWeek = (req, res) => {
-  var query = fs.readFileSync(path.join(__dirname, queryPath, 'GET/get_it-standards.sql')).toString() +
+  var query = IT_STANDARDS_BASE_QUERY +
     ` WHERE tech.ChangeDTG >= (CURDATE() - INTERVAL 7 DAY)
       GROUP BY tech.Id
       ORDER BY tech.ChangeDTG DESC;`;
 
-  res = ctrl.sendQuery(query, 'IT standard with change date in the last 7 days', res); 
+  res = ctrl.sendQuery(query, 'IT standard with change date in the last 7 days', res);
 };
 
 exports.findSystems = (req, res) => {
@@ -702,52 +803,40 @@ exports.getRelatedTRMS = (req, res) => {
 };
 
 exports.getFilterTotals = (req, res) => {
-  var filterQueryBase = 'AND (';
-  var filterQuery = '';
-  var filterQueryEnd  = ')';
-  var filterQueryFull = '';
-  if(req.params.filters && req.params.filters.length > 0) {
-    var filters = req.params.filters.split(',');
+  const chips = (req.params.filters || '').split(',').map(c => c.trim()).filter(Boolean);
+  const search = (req.query.search || '').trim();
 
-    for(i = 0; i < filters.length; i++) {
-      if(i === 0) {
-        filterQuery += `obj_deployment_type.Keyname = '${filters[i]}'`;
-      } else {
-        filterQuery += ` OR obj_deployment_type.Keyname = '${filters[i]}'`;
-      }
-    }
-
-    filterQueryFull = filterQueryBase + filterQuery + filterQueryEnd;
+  let filterClause = '';
+  if (chips.length > 0) {
+    filterClause = ` AND obj_deployment_type.Keyname IN (${chips.map(c => SqlString.escape(c)).join(',')})`;
   }
 
-  var allQuery = '';
-  if(!filterQueryFull) {
-    allQuery = '*';
-  } else {
-    allQuery = `CASE WHEN (${filterQuery}) THEN 1 ELSE NULL END`;
+  let searchClause = '';
+  if (search) {
+    const escaped = SqlString.escape('%' + search + '%');
+    searchClause = ` AND (
+      IFNULL(tech.softwareReleaseName, tech.Keyname) LIKE ${escaped}
+      OR tech.manufacturerName LIKE ${escaped}
+      OR tech.Description LIKE ${escaped}
+      OR obj_technology_status.Keyname LIKE ${escaped}
+      OR obj_deployment_type.Keyname LIKE ${escaped}
+    )`;
   }
 
-  var query = `SELECT COUNT(CASE WHEN obj_technology_status.Keyname = 'Approved' ${filterQueryFull} THEN 1
-                  ELSE NULL
-                END) AS ApprovedTotal,
-                COUNT(CASE WHEN obj_technology_status.Keyname = 'Denied' ${filterQueryFull} THEN 1
-                  ELSE NULL
-                END) AS DeniedTotal,
-                COUNT(CASE WHEN obj_technology_status.Keyname = 'Retired' ${filterQueryFull} THEN 1
-                  ELSE NULL
-                END) AS RetiredTotal,
-                COUNT(CASE WHEN (obj_technology_status.Keyname != 'Approved' 
-                            AND obj_technology_status.Keyname != 'Denied' 
-                            AND obj_technology_status.Keyname != 'Retired') ${filterQueryFull} THEN 1
-                     ELSE NULL
-              END) AS OtherTotal,
-                COUNT(${allQuery}) AS AllTotal
+  var query = `SELECT
+                COUNT(CASE WHEN (${EFFECTIVE_STATUS_EXPR}) = 'Approved' THEN 1 ELSE NULL END) AS ApprovedTotal,
+                COUNT(CASE WHEN (${EFFECTIVE_STATUS_EXPR}) = 'Denied' THEN 1 ELSE NULL END) AS DeniedTotal,
+                COUNT(CASE WHEN (${EFFECTIVE_STATUS_EXPR}) = 'Retired' THEN 1 ELSE NULL END) AS RetiredTotal,
+                COUNT(CASE WHEN (${EFFECTIVE_STATUS_EXPR}) NOT IN ('Approved','Denied','Retired') THEN 1 ELSE NULL END) AS OtherTotal,
+                COUNT(*) AS AllTotal
               FROM obj_technology AS tech
               LEFT JOIN obj_technology_status   ON tech.obj_technology_status_Id = obj_technology_status.Id
               LEFT JOIN obj_standard_type       ON tech.obj_standard_type_Id = obj_standard_type.Id
               LEFT JOIN obj_deployment_type     ON tech.obj_deployment_type_Id = obj_deployment_type.Id
               WHERE obj_standard_type.Keyname LIKE 'Software'
-              AND obj_technology_status.Keyname NOT LIKE 'Not yet submitted'`;
+              AND obj_technology_status.Keyname NOT LIKE 'Not yet submitted'
+              ${filterClause}
+              ${searchClause};`;
 
   res = ctrl.sendQuery(query, `IT Standards filter totals`, res);
 };

--- a/api/routes/it-standards.routes.js
+++ b/api/routes/it-standards.routes.js
@@ -6,6 +6,9 @@ const router = express.Router();
 router.route('/')
   .get(itsCtrl.findAll);
 
+router.route('/paginated')
+  .get(itsCtrl.findPaginated);
+
 router.route('/get/lite')
   .get(itsCtrl.getStandardsLite);
 

--- a/src/app/components/filter-chips/filter-chips.component.ts
+++ b/src/app/components/filter-chips/filter-chips.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, ViewChild, ElementRef, Input, Output, Renderer2 } from '@angular/core';
+import { Component, EventEmitter, ViewChild, ElementRef, Input, OnChanges, Output, Renderer2, SimpleChanges } from '@angular/core';
 
 @Component({
     selector: 'app-filter-chips',
@@ -6,12 +6,18 @@ import { Component, EventEmitter, ViewChild, ElementRef, Input, Output, Renderer
     styleUrls: ['./filter-chips.component.scss'],
     standalone: false
 })
-export class FilterChipsComponent {
+export class FilterChipsComponent implements OnChanges {
 
   @ViewChild('button') button: ElementRef;
   @ViewChild('menu') menu: ElementRef;
 
   @Input() chips: string[] = [];
+  // Currently-applied selection, e.g. restored from the URL. Kept in sync
+  // with displayedChips so the pills survive this component being
+  // recreated (Angular destroys/recreates it whenever the parent route
+  // navigates between /it_standards and /it_standards/filtered/... since
+  // those are distinct route configs).
+  @Input() selectedChips: string[] = [];
   @Input() dropdownName: string = '';
   @Output() chipSelect: EventEmitter<string[]> = new EventEmitter<string[]>();
 
@@ -27,6 +33,12 @@ export class FilterChipsComponent {
           }
         }
       });
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+      if (changes['selectedChips']) {
+        this.displayedChips = [...(this.selectedChips || [])];
+      }
     }
 
     public onDropdownClick(): void {

--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -1,4 +1,4 @@
-@if (isDataReady && !isSearchLoading) {
+@if (hasEverLoaded && !isSearchLoading) {
   <div class="table-responsive-container">
     <div class="d-flex justify-content-between">
       <div></div>
@@ -19,6 +19,7 @@
       [paginator]="showPagination"
       [lazy]="serverSidePagination"
       [lazyLoadOnInit]="serverSidePagination"
+      [loading]="serverSidePagination && !isDataReady"
       [totalRecords]="serverSidePagination ? serverSideTotalRecords : tableData.length"
       [scrollable]="true"
       [scrollHeight]="screenHeight"

--- a/src/app/components/table/table.component.html
+++ b/src/app/components/table/table.component.html
@@ -138,7 +138,7 @@
                       <span [ngClass]="col.class">{{ rowData[col.field] }}</span>
                     }
                     @if (col.formatter) {
-                      <span [ngClass]="col.class" [innerHTML]="col.formatter(rowData[col.field])"></span>
+                      <span [ngClass]="col.class" [innerHTML]="rowData[col.field] | applyFormatter:col.formatter"></span>
                     }
                   </td>
                 }

--- a/src/app/components/table/table.component.ts
+++ b/src/app/components/table/table.component.ts
@@ -125,6 +125,11 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
   matchModeOptions: SelectItem[];
 
   isDataReady: boolean = false;
+  // Latches true the first time data loads and never resets, so the
+  // paginator's own [lazy] table isn't torn down and recreated (and its
+  // lazyLoadOnInit re-triggered) every time isDataReady pulses false while
+  // a later page/sort/filter refresh is in flight.
+  hasEverLoaded: boolean = false;
   isSearchLoading: boolean = false;
 
   tableSearchControl = new FormControl('');
@@ -186,6 +191,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
       this.tableData = this.localTableData;
       this.originalTableData = [...this.localTableData];
       this.isDataReady = true;
+      this.hasEverLoaded = true;
     } else {
       this.tableDataSubscription = this.tableService.reportTableData$.subscribe(d => {
         if (this.isHandlingDataUpdate) return;
@@ -198,6 +204,9 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
       });
       this.tableReadySubscription = this.tableService.reportTableDataReady$.subscribe(r => {
         this.isDataReady = r;
+        if (r) {
+          this.hasEverLoaded = true;
+        }
       });
     }
     

--- a/src/app/pipes/apply-formatter.pipe.ts
+++ b/src/app/pipes/apply-formatter.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+/*
+ * Applies a table column's formatter function to a cell value.
+ * Pure by default, so Angular only re-invokes transform() when
+ * value or formatter change reference, unlike a plain method call
+ * in a template which re-runs on every change-detection cycle.
+ * Usage:
+ *   value | applyFormatter:formatter
+ */
+@Pipe({
+  standalone: false,
+  name: 'applyFormatter'
+})
+export class ApplyFormatterPipe implements PipeTransform {
+  transform(value: any, formatter: Function): any {
+    return formatter ? formatter(value) : value;
+  }
+}

--- a/src/app/services/apis/api.service.ts
+++ b/src/app/services/apis/api.service.ts
@@ -748,7 +748,35 @@ export class ApiService {
         catchError(this.handleError<ITStandards[]>('GET IT Standards Lite', []))
       );
   }
-  
+
+  public getITStandardsPaginated(
+    page: number,
+    pageSize: number,
+    sortField: string = 'Name',
+    sortOrder: number = 1,
+    search: string = '',
+    tab: string = 'All',
+    chips: string[] = [],
+    expiringWithinDays: number = 0,
+    retiredWithinDays: number = 0,
+    pastDueOnly: boolean = false,
+    includePastDue: boolean = false
+  ): Observable<{ total: number; data: ITStandards[] }> {
+    const params: any = { page, pageSize, sortField, sortOrder, tab };
+    if (search) { params.search = search; }
+    if (chips && chips.length > 0) { params.chips = chips.join(','); }
+    if (expiringWithinDays > 0) { params.expiringWithinDays = expiringWithinDays; }
+    if (retiredWithinDays > 0) { params.retiredWithinDays = retiredWithinDays; }
+    if (pastDueOnly) { params.pastDueOnly = 'true'; }
+    if (includePastDue) { params.includePastDue = 'true'; }
+
+    return this.http
+      .get<{ total: number; data: ITStandards[] }>(this.techUrl + '/paginated', { params })
+      .pipe(
+        catchError(this.handleError<{ total: number; data: ITStandards[] }>('GET IT Standards Paginated', { total: 0, data: [] }))
+      );
+  }
+
   public getApprovedITStandards(): Observable<ITStandards[]> {
     return this.http
       .get<ITStandards[]>(this.techUrl + '/get/findAllApproved')
@@ -756,9 +784,12 @@ export class ApiService {
         catchError(this.handleError<ITStandards[]>('GET IT Standards', []))
       );
   }
-  public getITStandardsFilterTotals(filters: string[]): Observable<any> {
+  public getITStandardsFilterTotals(chips: string[] = [], search: string = ''): Observable<any> {
+    const params: any = {};
+    if (search) { params.search = search; }
+    const path = chips && chips.length > 0 ? '/filter_totals/' + chips.join(',') : '/filter_totals';
     return this.http
-    .get<any>(this.techUrl + '/filter_totals/' + filters)
+    .get<any>(this.techUrl + path, { params })
     .pipe(
       map(t => t[0]),
       catchError(this.handleError<any>('GET IT Standards Filter Totals', []))
@@ -1147,9 +1178,9 @@ export class ApiService {
 
   // Get Data Dictionary By Report Name
   public getDataDictionaryByReportName(reportName: string): Observable<DataDictionary[]> {
-    return this.http
+    return this.getCached('data-dictionary:' + reportName, this.http
       .get<DataDictionary[]>(this.dataDictionaryUrl + '/get/' + encodeURIComponent(reportName))
-      .pipe(catchError(this.handleError<DataDictionary[]>('GET Data Dictionary By Report Name', [])));
+      .pipe(catchError(this.handleError<DataDictionary[]>('GET Data Dictionary By Report Name', []))));
   }
 
   //// TRM

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -29,6 +29,7 @@ import { ButtonOverlayPanelComponent } from '../components/button-overlay-panel/
 import { SidebarButtonComponent } from '../components/sidebar-button/sidebar-button.component';
 import { PageHelpButtonComponent } from '../components/page-help-button/page-help-button.component';
 import { YesNoPipe } from '../pipes/yesno.pipe';
+import { ApplyFormatterPipe } from '../pipes/apply-formatter.pipe';
 import { SkipFocusPiechartDirective } from '../common/skip-focus-piechart.directive';
 import { TableColumnFilterModalComponent } from '../components/modals/table-column-filter-modal/table-column-filter-modal.component';
 
@@ -42,6 +43,7 @@ const SHARED_DECLARATIONS = [
   SidebarButtonComponent,
   PageHelpButtonComponent,
   YesNoPipe,
+  ApplyFormatterPipe,
   SkipFocusPiechartDirective,
   TableColumnFilterModalComponent,
 ];

--- a/src/app/views/technologies/it-standards/it-standards.component.html
+++ b/src/app/views/technologies/it-standards/it-standards.component.html
@@ -20,7 +20,7 @@
     </p>
     </div>
     <div class="it-standards-data-container">
-      <app-filter-chips [chips]="filterChips" dropdownName="Deployment Types" (chipSelect)="onFilterChipSelect($event)"></app-filter-chips>
+      <app-filter-chips [chips]="filterChips" [selectedChips]="selectedChips" dropdownName="Deployment Types" (chipSelect)="onFilterChipSelect($event)"></app-filter-chips>
       @if (filterTotals) {
         <div>
           <app-table visibleColumnStorageKey="it-standards-report" [tableCols]="tableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" defaultSortField="Name" [serverSidePagination]="true" [serverSideTotalRecords]="totalRecords" (lazyLoadEvent)="loadPage($event)" (rowClickEvent)="onRowClick($event)">

--- a/src/app/views/technologies/it-standards/it-standards.component.html
+++ b/src/app/views/technologies/it-standards/it-standards.component.html
@@ -23,7 +23,7 @@
       <app-filter-chips [chips]="filterChips" dropdownName="Deployment Types" (chipSelect)="onFilterChipSelect($event)"></app-filter-chips>
       @if (filterTotals) {
         <div>
-          <app-table visibleColumnStorageKey="it-standards-report" [tableCols]="tableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" defaultSortField="Name" (rowClickEvent)="onRowClick($event)">
+          <app-table visibleColumnStorageKey="it-standards-report" [tableCols]="tableCols" [showToolbar]="true" [showPagination]="true" reportStyle="neutral" defaultSortField="Name" [serverSidePagination]="true" [serverSideTotalRecords]="totalRecords" (lazyLoadEvent)="loadPage($event)" (rowClickEvent)="onRowClick($event)">
             <div class="filter-tabs-container" filterTabs>
               <div class="filter-tab" [ngClass]="{'selected': isTabSelected('All')}" (click)="onSelectTab('All')" (keyup)="onKeyUp($event, 'All')" tabindex="0">
                 <span class="filter-tab-text">All</span>

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -101,7 +101,11 @@ export class ItStandardsComponent implements OnInit, OnDestroy {
   }
 
   private syncUrlToFilters(): void {
-    const chip = this.selectedChips.length === 1 ? this.selectedChips[0] : null;
+    // Comma-join so multiple selected chips all survive being re-parsed
+    // out of the URL after this component gets recreated (Angular treats
+    // /it_standards, /it_standards/filtered/:x and /it_standards/filtered/:x/:y
+    // as distinct route configs, so it destroys/recreates on every switch).
+    const chip = this.selectedChips.length > 0 ? this.selectedChips.join(',') : null;
     const tab = this.selectedTab;
 
     if (chip && tab && tab !== 'All') {
@@ -157,12 +161,13 @@ export class ItStandardsComponent implements OnInit, OnDestroy {
     */
 
     // Support deep-link filtered URLs: /it_standards/filtered/:deploymentType/:status
+    // :deploymentType may be a comma-separated list to support multi-select chips.
     const routeParams = this.route.snapshot.params;
     if (routeParams['deploymentType']) {
-      const depType = routeParams['deploymentType'];
-      const match = this.filterChips.find(c => c.toLowerCase() === depType.toLowerCase());
-      if (match) {
-        this.selectedChips = [match];
+      const depTypes = (routeParams['deploymentType'] as string).split(',').map(d => d.trim().toLowerCase());
+      const matches = this.filterChips.filter(c => depTypes.includes(c.toLowerCase()));
+      if (matches.length > 0) {
+        this.selectedChips = matches;
       }
     }
     if (routeParams['status']) {

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { forkJoin } from 'rxjs';
+import { Subscription } from 'rxjs';
 
 import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
@@ -21,23 +21,14 @@ import { Column } from '@common/table-classes';
     styleUrls: ['./it-standards.component.scss'],
     standalone: false
 })
-export class ItStandardsComponent implements OnInit {
+export class ItStandardsComponent implements OnInit, OnDestroy {
 
-  private readonly otherStatuses: string[] = ['Approved', 'Denied', 'Retired'];
-
-  // row: Object = <any>{};
-  // filteredTable: boolean = false;
-  // filterTitle: string = '';
   attrDefinitions: DataDictionary[] = [];
-  // columnDefs: any[] = [];
-  // dataReady: boolean = false;
 
   public tableCols: Column[] = [];
   public selectedTab: string = 'All';
   public filterTotals: any = null;
-  public itStandardsData: ITStandards[] = [];
-  public itStandardsDataTabFilterted: ITStandards[] = [];
-  public itStandardsDataChipFilterted: ITStandards[] = [];
+  public totalRecords: number = 0;
   public filterChips: string[] = ['Mobile', 'Desktop', 'Server', 'SaaS', 'PaaS', 'Other'];
   private selectedChips: string[] = [];
 
@@ -46,7 +37,13 @@ export class ItStandardsComponent implements OnInit {
   public includePastDueExpirations: boolean = false;
   public pastDueOnly: boolean = false;
 
-  public isDataReady: boolean = false;
+  // Sticky paging/sort/search state, preserved across tab and chip changes.
+  private currentSortField: string = 'Name';
+  private currentSortOrder: number = 1;
+  private currentSearch: string = '';
+  private currentPageSize: number = 50;
+
+  private queryParamsSubscription?: Subscription;
 
   constructor(
     private apiService: ApiService,
@@ -71,46 +68,17 @@ export class ItStandardsComponent implements OnInit {
   public onSelectTab(tabName: string): void {
     this.selectedTab = tabName;
     this.syncUrlToFilters();
-    this.itStandardsDataTabFilterted = this.itStandardsData;
-
-    if(this.selectedTab === 'All') {
-      if(this.hasSelectedChips()) {
-        this.onFilterChipSelect(this.selectedChips);
-      } else {
-        this.tableService.updateReportTableData(this.itStandardsDataTabFilterted);
-        //this.tableService.updateReportTableDataReadyStatus(true);
-      }
-    } else if (this.selectedTab === 'Other') {
-      if(this.hasSelectedChips()) {
-        this.itStandardsDataTabFilterted = this.itStandardsDataTabFilterted.filter(x => {
-          return x.Status !== 'Approved' && x.Status !== 'Denied' && x.Status !== 'Retired';
-        });
-        this.onFilterChipSelect(this.selectedChips);
-      } else {
-        this.itStandardsDataTabFilterted = this.itStandardsDataTabFilterted.filter(x => {
-          return x.Status !== 'Approved' && x.Status !== 'Denied' && x.Status !== 'Retired' && x.Status !== 'Approved with conditions';
-        });
-        this.tableService.updateReportTableData(this.itStandardsDataTabFilterted);
-        //this.tableService.updateReportTableDataReadyStatus(true);
-      }
-    } else {
-      if(this.hasSelectedChips()) {
-        this.itStandardsDataTabFilterted = this.itStandardsDataTabFilterted.filter(x => {
-          return x.Status === tabName;
-        });
-        this.onFilterChipSelect(this.selectedChips);
-      } else {
-        this.itStandardsDataTabFilterted = this.itStandardsDataTabFilterted.filter(x => {
-          return x.Status === tabName;
-        });
-        this.tableService.updateReportTableData(this.itStandardsDataTabFilterted);
-        //this.tableService.updateReportTableDataReadyStatus(true);
-      }
-    }
+    this.loadPage({
+      page: 1,
+      pageSize: this.currentPageSize,
+      sortField: this.currentSortField,
+      sortOrder: this.currentSortOrder,
+      search: this.currentSearch,
+    });
   }
 
   public onKeyUp(e: KeyboardEvent, tabName: string) {
-    if(e.key === ' ' || e.key === 'Enter') {
+    if (e.key === ' ' || e.key === 'Enter') {
       this.onSelectTab(tabName);
     }
   }
@@ -118,26 +86,18 @@ export class ItStandardsComponent implements OnInit {
   public onFilterChipSelect(selectedChips: string[]): void {
     this.selectedChips = selectedChips;
     this.syncUrlToFilters();
-    this.itStandardsDataChipFilterted = this.itStandardsDataTabFilterted;
-    if(this.hasSelectedChips()) {
-      this.itStandardsDataChipFilterted = this.itStandardsDataTabFilterted.filter(f => {
-        return selectedChips.includes(f.DeploymentType);
-      });
-      this.tableService.updateReportTableData(this.itStandardsDataChipFilterted);
-      this.tableService.updateReportTableDataReadyStatus(true);
-    } else {
-      this.itStandardsDataChipFilterted = this.itStandardsDataTabFilterted;
-      this.onSelectTab(this.selectedTab);
-    }
-    this.updateTotals();
+    this.loadPage({
+      page: 1,
+      pageSize: this.currentPageSize,
+      sortField: this.currentSortField,
+      sortOrder: this.currentSortOrder,
+      search: this.currentSearch,
+    });
+    this.refreshTotals();
   }
 
   public isTabSelected(tabName: string): boolean {
     return this.selectedTab === tabName;
-  }
-
-  private hasSelectedChips(): boolean {
-    return this.selectedChips && this.selectedChips.length > 0;
   }
 
   private syncUrlToFilters(): void {
@@ -154,29 +114,40 @@ export class ItStandardsComponent implements OnInit {
   }
 
   private YesNo(value: any, row: any, index: number, field: string): string {
-    return value === 'T'? "Yes" : "No";
+    return value === 'T' ? "Yes" : "No";
   }
 
-  private updateTotals(): void {
-    const filteredData = this.hasSelectedChips()
-      ? this.itStandardsData.filter(standard => this.selectedChips.includes(standard.DeploymentType))
-      : this.itStandardsData;
+  private refreshTotals(): void {
+    this.apiService.getITStandardsFilterTotals(this.selectedChips).subscribe(totals => {
+      this.filterTotals = totals;
+    });
+  }
 
-    let approvedTotal = 0, deniedTotal = 0, retiredTotal = 0, otherTotal = 0;
-    for (const standard of filteredData) {
-      if (standard.Status === 'Approved') { approvedTotal++; }
-      else if (standard.Status === 'Denied') { deniedTotal++; }
-      else if (standard.Status === 'Retired') { retiredTotal++; }
-      else { otherTotal++; }
-    }
+  public loadPage(event: { page: number; pageSize: number; sortField: string; sortOrder: number; search: string }): void {
+    this.currentSortField = event.sortField || 'Name';
+    this.currentSortOrder = event.sortOrder || 1;
+    this.currentSearch = event.search || '';
+    this.currentPageSize = event.pageSize || this.currentPageSize;
 
-    this.filterTotals = {
-      ApprovedTotal: approvedTotal,
-      DeniedTotal: deniedTotal,
-      RetiredTotal: retiredTotal,
-      OtherTotal: otherTotal,
-      AllTotal: filteredData.length,
-    };
+    this.tableService.updateReportTableDataReadyStatus(false);
+    this.apiService.getITStandardsPaginated(
+      event.page,
+      this.currentPageSize,
+      this.currentSortField,
+      this.currentSortOrder,
+      this.currentSearch,
+      this.selectedTab,
+      this.selectedChips,
+      this.daysExpiring,
+      this.daysRetired,
+      this.pastDueOnly,
+      this.includePastDueExpirations
+    ).subscribe(result => {
+      const dataWithConditionStatus = this.setCondtionStatus(result.data);
+      this.totalRecords = result.total;
+      this.tableService.updateReportTableData(dataWithConditionStatus);
+      this.tableService.updateReportTableDataReadyStatus(true);
+    });
   }
 
   ngOnInit(): void {
@@ -199,11 +170,11 @@ export class ItStandardsComponent implements OnInit {
       this.selectedTab = status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
     }
 
-   this.route.queryParams.subscribe(params => {
+    this.queryParamsSubscription = this.route.queryParams.subscribe(params => {
       if (params['tab']) {
         this.selectedTab = params['tab'];
       }
-      if(params['expiringWithinDays']) {
+      if (params['expiringWithinDays']) {
         this.daysExpiring = +params['expiringWithinDays'];
       }
       if (params['includePastDue']) {
@@ -212,15 +183,15 @@ export class ItStandardsComponent implements OnInit {
       if (params['pastDueOnly']) {
         this.pastDueOnly = params['pastDueOnly'] === 'true';
       }
-      if(params['retiredWithinDays']) {
+      if (params['retiredWithinDays']) {
         this.daysRetired = +params['retiredWithinDays'];
       }
     });
-    
-    forkJoin({
-      defs: this.apiService.getDataDictionaryByReportName('IT Standards List'),
-      standards: this.apiService.getITStandards(),
-    }).subscribe(({ defs, standards }) => {
+
+    // Set JWT when logged into GEAR Manager when returning from secureAuth
+    this.sharedService.setJWTonLogIn();
+
+    this.apiService.getDataDictionaryByReportName('IT Standards List').subscribe(defs => {
       this.attrDefinitions = defs;
 
       // IT Standard Table Columns
@@ -317,14 +288,6 @@ export class ItStandardsComponent implements OnInit {
         showColumn: false,
         titleTooltip: this.sharedService.getTooltip(this.attrDefinitions, 'Software Release Name')
       },
-      //  {
-      //   field: 'EndOfLifeDate',
-      //   header: 'Vendor End of Life Date',
-      //   isSortable: true,
-      //   showColumn: false,
-      //   formatter: this.sharedService.dateFormatter,
-      //  titleTooltip: this.sharedService.getTooltip(this.attrDefinitions, 'Software End of Life Date')
-      // },
        {
         field: 'AlsoKnownAs',
         header: 'Also Known As',
@@ -369,19 +332,7 @@ export class ItStandardsComponent implements OnInit {
         showColumn: false,
         formatter: this.sharedService.formatDescription,
         titleTooltip: this.sharedService.getTooltip(this.attrDefinitions, 'Comments')
-      }, /*{
-        field: 'attestation_required',
-        header: 'Attestation Required',
-        isSortable: true,
-        showColumn: false,
-        titleTooltip: this.sharedService.getTooltip(this.attrDefinitions, 'Attestation Required')
       }, {
-        field: 'attestation_link',
-        header: 'Attestation Link',
-        isSortable: true,
-        showColumn: false,
-        titleTooltip: this.sharedService.getTooltip(this.attrDefinitions, 'Attestation Link')
-      }, */{
         field: 'fedramp',
         header: 'FedRAMP',
         isSortable: true,
@@ -438,145 +389,22 @@ export class ItStandardsComponent implements OnInit {
         titleTooltip: this.sharedService.getTooltip(this.attrDefinitions, 'C-SCRM Review Results')
       }];
 
-      // Set JWT when logged into GEAR Manager when returning from secureAuth
-      this.sharedService.setJWTonLogIn();
-
-      const i = standards;
-      const standardsWithConditionStatus = this.setCondtionStatus(i);
-      this.itStandardsData = standardsWithConditionStatus;
-      this.itStandardsDataTabFilterted = standardsWithConditionStatus;
-      this.itStandardsDataChipFilterted = standardsWithConditionStatus;
-      this.updateTotals();
-
-      const queryParams = this.route.snapshot.queryParams;
-      const daysExpiring = Number(queryParams['expiringWithinDays'] || this.daysExpiring || 0);
-      const daysRetired = Number(queryParams['retiredWithinDays'] || this.daysRetired || 0);
-      const includePastDue = queryParams['includePastDue'] === 'true' || this.includePastDueExpirations;
-      const pastDueOnly = queryParams['pastDueOnly'] === 'true' || this.pastDueOnly;
-
-      if(daysExpiring > 0) {
-        const now = new Date(); // Current date and time
-        now.setHours(0, 0, 0, 0);
-        const expiringWithin = new Date();
-        expiringWithin.setDate(now.getDate() + daysExpiring); // number of days set in the url
-        expiringWithin.setHours(0, 0, 0, 0);
-        const expiringFiltered: ITStandards[] = [];
-        i.forEach(x => {
-          let renewal = new Date(x.ApprovalExpirationDate);
-          renewal.setHours(0, 0, 0, 0);
-          const isInWindow = includePastDue
-            ? renewal <= expiringWithin
-            : (renewal >= now && renewal <= expiringWithin);
-          if(x.ApprovalExpirationDate && isInWindow && this.isInExpiringStatusScope(x)) {
-            expiringFiltered.push(x);
-          }
-        });
-        this.tableService.updateReportTableData(expiringFiltered);
-        this.tableService.updateReportTableDataReadyStatus(true);
-      } else if (pastDueOnly) {
-        const now = new Date();
-        now.setHours(0, 0, 0, 0);
-        const pastDueFiltered: ITStandards[] = [];
-        i.forEach(x => {
-          let renewal = new Date(x.ApprovalExpirationDate);
-          renewal.setHours(0, 0, 0, 0);
-          if (x.ApprovalExpirationDate && renewal < now && this.isInExpiringStatusScope(x)) {
-            pastDueFiltered.push(x);
-          }
-        });
-        this.tableService.updateReportTableData(pastDueFiltered);
-        this.tableService.updateReportTableDataReadyStatus(true);
-      } else if(daysRetired > 0) {
-        const now = new Date(); // Current date and time
-        now.setHours(0, 0, 0, 0);
-        const expiredWithin = new Date();
-        expiredWithin.setDate(now.getDate() - daysRetired); // number of days set in the url
-        expiredWithin.setHours(0, 0, 0, 0);
-        const expiringFiltered: ITStandards[] = [];
-        i.forEach(x => {
-          let renewal = new Date(x.ApprovalExpirationDate);
-          renewal.setHours(0, 0, 0, 0);
-          if(x.ApprovalExpirationDate && (renewal <= now && renewal >= expiredWithin) && (x.Status === 'Retired')) {
-            expiringFiltered.push(x);
-          }
-        });
-        this.tableService.updateReportTableData(expiringFiltered);
-        this.tableService.updateReportTableDataReadyStatus(true);
-      } else {
-        this.tableService.updateReportTableData(i);
-        this.tableService.updateReportTableDataReadyStatus(true);
-      }
-
-      // this.tableService.updateReportTableData(i);
-      
-      if (this.selectedTab !== 'All') {
-        this.onSelectTab(this.selectedTab);
-      }
-    }); // end forkJoin
-
-  //   // Method to open details modal when referenced directly via URL
-  //   this.route.params.subscribe((params) => {
-  //     let detailStandID = params['standardID'];
-  //     let deploymentType = params['deploymentType'];
-  //     let status = params['status'];
-
-  //     if(deploymentType) {
-  //       let filterButton = {
-  //         buttonText: deploymentType[0].toUpperCase() + deploymentType.slice(1),
-  //         filters: [
-  //           { field: 'DeploymentType', value: deploymentType.toLocaleLowerCase() }
-  //         ]
-  //       };
-  //       this.preloadedFilterButtons.push(filterButton);
-  //     }
-
-  //     if(status) {
-  //       let filterButton = {
-  //         buttonText: status[0].toUpperCase() + status.slice(1),
-  //         filters: [
-  //           { field: 'Status', value: status.toLocaleLowerCase() }
-  //         ]
-  //       };
-  //       this.preloadedFilterButtons.push(filterButton);
-  //     }
-
-  //     if (detailStandID) {
-  //       this.titleService.setTitle(
-  //         `${this.titleService.getTitle()} - ${detailStandID}`
-  //       );
-  //       this.apiService
-  //         .getOneITStandard(detailStandID)
-  //         .subscribe((data: any[]) => {
-  //           this.tableService.itStandTableClick(data[0]);
-  //         });
-  //     }
-  //   });
+      // Initial load: first page, using whatever tab/chip/date-filter state
+      // was parsed from the route above.
+      this.loadPage({
+        page: 1,
+        pageSize: this.currentPageSize,
+        sortField: this.currentSortField,
+        sortOrder: this.currentSortOrder,
+        search: this.currentSearch,
+      });
+      this.refreshTotals();
+    });
   }
 
-  // // Create new IT Standard when in GEAR Manager mode
-  // createITStand() {
-  //   var emptyITStand = new ITStandards();
-
-  //   // By default, set new record status to "Pilot"
-  //   emptyITStand.Status = 'Pilot';
-  //   this.modalService.updateRecordCreation(true);
-  //   this.sharedService.setITStandardsForm();
-  //   this.modalService.updateDetails(emptyITStand, 'it-standard', false);
-  //   $('#itStandardsManager').modal('show');
-
-  //   // disable the tcSoftwareProduct on the itStandardsManager modal
-  //   $('#divProduct').addClass("disabledDivProduct");
-  //   $('#divVersion').addClass("disabledDivVersion");
-  //   $('#divRelease').addClass("disabledDivRelease");
-  // }
-
-  // getTooltip (name: string): string {
-  //   const def = this.attrDefinitions.find(def => def.Term === name);
-  //   if(def){
-  //     return def.TermDefinition;
-  //   }
-  //   return '';
-  // }
+  ngOnDestroy(): void {
+    this.queryParamsSubscription?.unsubscribe();
+  }
 
   public onRowClick(e: any) {
     const searchTerm: string = e.tableSearchString || '';
@@ -585,37 +413,12 @@ export class ItStandardsComponent implements OnInit {
     });
   }
 
-  // onFilterClick(filterButtons: FilterButton[]) {
-  //   this.tableData = this.tableDataOriginal;
-  //   this.tableService.filterButtonClick(filterButtons, this.tableData);
-  // }
-
-  // onFilterResetClick() {
-  //   this.tableData = this.tableDataOriginal;
-  //   this.tableService.updateReportTableData(this.tableDataOriginal);
-  // }
-
   private setCondtionStatus(itStandards: ITStandards[]): ITStandards[] {
     itStandards.forEach(i => {
-      if(i.ConditionsRestrictions && i.ConditionsRestrictions.length > 0) {
+      if (i.ConditionsRestrictions && i.ConditionsRestrictions.length > 0) {
         i.Status = 'Approved with conditions';
       }
     });
     return itStandards;
-  }
-
-  // Keep dashboard deep-link filters consistent with backend totals query scope.
-  private isInExpiringStatusScope(standard: ITStandards): boolean {
-    const approvedLikeStatusIds = [11, 2, 6, 9];
-
-    if (typeof standard.StatusId === 'number') {
-      return approvedLikeStatusIds.includes(standard.StatusId);
-    }
-
-    return standard.Status === 'Approved'
-      || standard.Status === 'Approved with conditions'
-      || standard.Status === 'Pilot'
-      || standard.Status === 'Exception'
-      || standard.Status === 'Sunsetting';
   }
 }

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -30,7 +30,7 @@ export class ItStandardsComponent implements OnInit, OnDestroy {
   public filterTotals: any = null;
   public totalRecords: number = 0;
   public filterChips: string[] = ['Mobile', 'Desktop', 'Server', 'SaaS', 'PaaS', 'Other'];
-  private selectedChips: string[] = [];
+  public selectedChips: string[] = [];
 
   public daysExpiring: number = 0;
   public daysRetired: number = 0;
@@ -84,7 +84,7 @@ export class ItStandardsComponent implements OnInit, OnDestroy {
   }
 
   public onFilterChipSelect(selectedChips: string[]): void {
-    this.selectedChips = selectedChips;
+    this.selectedChips = [...selectedChips];
     this.syncUrlToFilters();
     this.loadPage({
       page: 1,


### PR DESCRIPTION
Some performance changes + bug fixes:

- api/controllers/it-standards.controller.js: SQL template cached at module load; new findPaginated handler with real LIMIT/OFFSET, sort allowlist, search, tab/status filtering (including the derived "Approved with conditions" status), deployment-type chip filtering, and the three dashboard date-window filters — all inputs escaped via SqlString.escape; getFilterTotals fixed to correctly split "Approved with conditions" out of the Approved bucket and to accept a search param.
- api/routes/it-standards.routes.js: registered GET /paginated.

- api.service.ts: added getITStandardsPaginated(), updated getITStandardsFilterTotals(), cached getDataDictionaryByReportName().
- it-standards.component.ts/.html: now fetches one page at a time instead of the full dataset, fixed the leaked queryParams subscription with a proper ngOnDestroy, and removed the redundant double-render on filtered deep links.
- table.component.html + new src/app/pipes/apply-formatter.pipe.ts: per-cell formatter calls converted to a pure pipe, so they stop re-running on every change-detection cycle.

- bug fix for deploment type filters not showing the selected pills and resetting once a second filter is selected.